### PR TITLE
Add project import and export

### DIFF
--- a/components/PromptPanel.tsx
+++ b/components/PromptPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { buildPrompt } from "@/lib/prompt";
-import { Doc, KIND_ORDER, Kind, Palette } from "@/lib/tokens";
+import { Doc, KIND_ORDER, Kind, Palette, VARIANTS } from "@/lib/tokens";
 import { Icon } from "./M3Node";
 import { Field, IconBtn } from "./ui";
 import { t, useLang } from "@/lib/i18n";
@@ -29,7 +29,7 @@ const isProject = (value: unknown): value is Doc => {
     kinds.has(item.kind as Kind) &&
     typeof item.label === "string" &&
     (typeof item.icon === "string" || item.icon === null) &&
-    typeof item.variant === "string" &&
+    VARIANTS.some((variant) => variant.key === item.variant) &&
     (item.supporting === undefined || typeof item.supporting === "string") &&
     (item.note === undefined || typeof item.note === "string") &&
     validTabs(item.tabs);


### PR DESCRIPTION
## What and why

Projects currently live only in the browser's `localStorage`, so an editable canvas cannot be backed up or moved to another browser.

This adds two compact actions to the prompt panel:

- **Save project** downloads the current `Doc` as `m3e-canvas.json`.
- **Open project** reads the same JSON structure and restores it after confirmation.

Import performs a minimal check for the document's `groups` and `frames`, then restores the document and clears transient editor state. No new file format, schema, migration layer, or dependency is introduced.

The new labels and messages are provided in Japanese, English, and Chinese.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] New or changed UI strings and prompt text exist in Japanese, English and Chinese
- [x] Tried it in the editor (and on a phone, if the change touches the phone editor)

## Screenshots

The desktop prompt panel now shows **Save project** and **Open project** above the generated prompt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project import and export so canvases can be backed up or moved between browsers instead of living only in `localStorage`.

- Save project downloads the current document as `m3e-canvas.json`.
- Open project validates groups, frames, items, and component variants before restoring after confirmation and clearing transient editor state.
- New UI strings are localized in Japanese, English, and Chinese.

<sup>Written for commit 71dda820dfa19d3ae7f7904db794ac57e6acca52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

