### PR TITLE
Add phone and desktop frame size presets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,15 +24,19 @@ import {
   clamp,
   connectSpecOf,
   DEFAULT_PLATFORM,
+  DESKTOP_R,
   Doc,
   isPlatform,
   Platform,
   Frame,
+  FramePreset,
   FRAME_GAP,
   FRAME_LABEL_H,
   FrameMode,
   frameOfGroup,
+  framePresetPatch,
   frameRect,
+  frameSizeOf,
   GAP,
   Group,
   groupBounds,
@@ -67,10 +71,11 @@ import {
   TRANSITIONS,
   uid,
   uniformRadii,
+  isPhoneFrame,
 } from "@/lib/tokens";
 import { Icon, M3Node, M3Static, MeasuredContent } from "@/components/M3Node";
 import { LayersPanel } from "@/components/Layers";
-import { FrameInspector, Inspector } from "@/components/Inspector";
+import { FrameInspector, FrameSizePicker, Inspector } from "@/components/Inspector";
 import { Preview } from "@/components/Preview";
 import { Logo } from "@/components/Logo";
 import { PartsPalette } from "@/components/PartsPalette";
@@ -169,8 +174,11 @@ function migrateGroups(groups: Group[], frames: Frame[]): Group[] {
   const oldNavH = KIND_SPEC.bottomNav.h - NAV_BAR_H;
   return groups.map((g) => {
     if (g.items.length !== 1 || g.items[0].kind !== "bottomNav") return g;
-    const f = frames.find((fr) => g.x >= fr.x - 1 && g.x <= fr.x + PHONE_W && g.y === fr.y + PHONE_H - oldNavH);
-    return f ? { ...g, y: f.y + PHONE_H - KIND_SPEC.bottomNav.h } : g;
+    const f = frames.find((fr) => {
+      const r = frameRect(fr);
+      return g.x >= r.l - 1 && g.x <= r.r && g.y === r.b - oldNavH;
+    });
+    return f ? { ...g, y: frameRect(f).b - KIND_SPEC.bottomNav.h } : g;
   });
 }
 
@@ -231,10 +239,12 @@ const mobileSeed = (): Group[] => {
 };
 
 /** While the model works on a screen, the scheme's colors drift through its bezel. */
-function ThinkingRing({ p }: { p: Palette }) {
+function ThinkingRing({ p, frame }: { p: Palette; frame: Frame }) {
   const still = useReducedMotion();
-  const w = PHONE_W + BEZEL * 2;
-  const h = PHONE_H + BEZEL * 2;
+  const { w: frameW, h: frameH } = frameSizeOf(frame);
+  const inset = isPhoneFrame(frame) ? BEZEL : 0;
+  const w = frameW + inset * 2;
+  const h = frameH + inset * 2;
   const d = Math.ceil(Math.hypot(w, h)) + 80;
   const stops = [p.primary, p.tertiaryContainer, p.inversePrimary, p.secondaryContainer, p.primaryContainer, p.primary];
   return (
@@ -680,10 +690,10 @@ export default function Page() {
     let y1 = PHONE_H + BEZEL;
     const fs = framesRef.current;
     if (frameRef.current === "phone" && fs.length > 0) {
-      x0 = Math.min(...fs.map((f) => f.x)) - BEZEL;
-      y0 = Math.min(...fs.map((f) => f.y)) - BEZEL - FRAME_LABEL_H;
-      x1 = Math.max(...fs.map((f) => f.x)) + PHONE_W + BEZEL;
-      y1 = Math.max(...fs.map((f) => f.y)) + PHONE_H + BEZEL;
+      x0 = Math.min(...fs.map((f) => f.x - (isPhoneFrame(f) ? BEZEL : 0)));
+      y0 = Math.min(...fs.map((f) => f.y - (isPhoneFrame(f) ? BEZEL : 0))) - FRAME_LABEL_H;
+      x1 = Math.max(...fs.map((f) => frameRect(f).r + (isPhoneFrame(f) ? BEZEL : 0)));
+      y1 = Math.max(...fs.map((f) => frameRect(f).b + (isPhoneFrame(f) ? BEZEL : 0)));
     }
     if (frameRef.current === "blank") {
       if (gs.length === 0) {
@@ -869,19 +879,20 @@ export default function Page() {
       }
       if (frameRef.current === "phone") {
         for (const f of framesRef.current) {
+          const { w, h } = frameSizeOf(f);
           xs.push(
             f.x,
             f.x + FRAME_MARGIN,
-            f.x + PHONE_W / 2,
-            f.x + PHONE_W - FRAME_MARGIN,
-            f.x + PHONE_W,
+            f.x + w / 2,
+            f.x + w - FRAME_MARGIN,
+            f.x + w,
           );
           ys.push(
             f.y,
             f.y + FRAME_MARGIN,
-            f.y + PHONE_H / 2,
-            f.y + PHONE_H - FRAME_MARGIN,
-            f.y + PHONE_H,
+            f.y + h / 2,
+            f.y + h - FRAME_MARGIN,
+            f.y + h,
           );
         }
       }
@@ -1161,12 +1172,22 @@ export default function Page() {
         return;
       }
       if (d.fromPalette) snapshot();
+      const targetFrame = framesRef.current.find((f) => {
+        const r = frameRect(f);
+        const cx = rawX + sz.w / 2;
+        const cy = rawY + sz.h / 2;
+        return cx >= r.l && cx <= r.r && cy >= r.t && cy <= r.b;
+      });
+      const placedItem =
+        targetFrame && (item.kind === "topAppBar" || item.kind === "bottomNav")
+          ? { ...item, size: frameSizeOf(targetFrame).w }
+          : item;
       const ng: Group = {
         id: uid(),
         x: Math.round(rawX),
         y: Math.round(rawY),
         axis: connectSpecOf(item)?.axis ?? "x",
-        items: [item],
+        items: [placedItem],
       };
       setGroups((prev) =>
         prev.some((g) => g.items.some((it) => it.id === item.id))
@@ -1432,6 +1453,7 @@ export default function Page() {
     if (g.items.length !== 1 || frameRef.current !== "phone") return none;
     const f = frameOfGroup(g, framesRef.current, widthsRef.current);
     if (!f) return none;
+    const { w: frameW, h: frameH } = frameSizeOf(f);
     const a = sizeOf(before, widthsRef.current);
     const b = sizeOf(after, widthsRef.current);
     const shift = (pos: number, len: number, next: number, f0: number, fLen: number) => {
@@ -1443,8 +1465,8 @@ export default function Page() {
       return 0;
     };
     return {
-      dx: shift(g.x, a.w, b.w, f.x, PHONE_W),
-      dy: shift(g.y, a.h, b.h, f.y, PHONE_H),
+      dx: shift(g.x, a.w, b.w, f.x, frameW),
+      dy: shift(g.y, a.h, b.h, f.y, frameH),
     };
   };
 
@@ -1687,6 +1709,11 @@ export default function Page() {
     () => frames.find((f) => f.id === selectedFrameId) ?? null,
     [frames, selectedFrameId],
   );
+  const selectedPartFrame = useMemo(() => {
+    if (!primaryId || frame !== "phone") return null;
+    const g = groups.find((g) => g.items.some((it) => it.id === primaryId));
+    return g ? (frameOfGroup(g, frames, widths) ?? null) : null;
+  }, [primaryId, frame, groups, frames, widths]);
 
   /** the screen the tidy button works on: the selected one, or the one under the selected part */
   const tidyTarget = useMemo((): Frame | null => {
@@ -1699,7 +1726,7 @@ export default function Page() {
 
   const nextFrameX = () =>
     framesRef.current.length
-      ? Math.max(...framesRef.current.map((f) => f.x)) + PHONE_W + FRAME_GAP
+      ? Math.max(...framesRef.current.map((f) => frameRect(f).r)) + FRAME_GAP
       : 0;
 
   /** Entering phone mode with no frames wraps the existing parts in one. */
@@ -1736,14 +1763,15 @@ export default function Page() {
     let x = ((r?.width ?? 0) / 2 - v.x) / v.z - sz.w / 2;
     let y = ((r?.height ?? 0) / 2 - v.y) / v.z - sz.h / 2;
     if (f) {
-      const lx = f.x + Math.min(FRAME_MARGIN, (PHONE_W - sz.w) / 2);
-      const ly = f.y + Math.min(FRAME_MARGIN, (PHONE_H - sz.h) / 2);
-      x = clamp(x, lx, Math.max(lx, f.x + PHONE_W - FRAME_MARGIN - sz.w));
-      y = clamp(y, ly, Math.max(ly, f.y + PHONE_H - FRAME_MARGIN - sz.h));
+      const { w, h } = frameSizeOf(f);
+      const lx = f.x + Math.min(FRAME_MARGIN, (w - sz.w) / 2);
+      const ly = f.y + Math.min(FRAME_MARGIN, (h - sz.h) / 2);
+      x = clamp(x, lx, Math.max(lx, f.x + w - FRAME_MARGIN - sz.w));
+      y = clamp(y, ly, Math.max(ly, f.y + h - FRAME_MARGIN - sz.h));
       const taken = (yy: number) =>
         itemRects().some((o) => o.l < x + sz.w && o.r > x && o.t < yy + sz.h && o.b > yy);
       let tries = 0;
-      while (taken(y) && y + sz.h * 2 < f.y + PHONE_H && tries++ < 12) y += sz.h + 12;
+      while (taken(y) && y + sz.h * 2 < f.y + h && tries++ < 12) y += sz.h + 12;
     }
     snapshot();
     setGroups((gs) => [
@@ -1787,9 +1815,10 @@ export default function Page() {
     const r = canvasRect();
     if (r) {
       const z = viewRef.current.z;
+      const { w, h } = frameSizeOf(f);
       setView({
-        x: r.width / 2 - (f.x + PHONE_W / 2) * z,
-        y: r.height / 2 - (f.y + PHONE_H / 2) * z,
+        x: r.width / 2 - (f.x + w / 2) * z,
+        y: r.height / 2 - (f.y + h / 2) * z,
         z,
       });
     }
@@ -1798,6 +1827,36 @@ export default function Page() {
   const patchFrame = (id: string, patch: Partial<Frame>) => {
     snapshotFor("frame:" + id + ":" + Object.keys(patch).join(","));
     setFrames((fs) => fs.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+  };
+
+  const setFramePreset = (id: string, preset: FramePreset) => {
+    const current = framesRef.current.find((f) => f.id === id);
+    if (!current) return;
+    const next = { ...current, ...framePresetPatch(preset) };
+    const before = frameSizeOf(current);
+    const after = frameSizeOf(next);
+    if (before.w === after.w && before.h === after.h) return;
+    const carried = new Set(
+      groupsRef.current
+        .filter((g) => frameOfGroup(g, framesRef.current, widthsRef.current)?.id === id)
+        .map((g) => g.id),
+    );
+    snapshot();
+    tidyRef.current = null;
+    setFrames((fs) => fs.map((f) => (f.id === id ? next : f)));
+    setGroups((gs) =>
+      gs.map((g) =>
+        carried.has(g.id)
+          ? {
+              ...g,
+              items: g.items.map((it) =>
+                it.kind === "topAppBar" || it.kind === "bottomNav" ? { ...it, size: after.w } : it,
+              ),
+            }
+          : g,
+      ),
+    );
+    queueMicrotask(() => fitRef.current());
   };
 
   /** the tidy button's state for the screen in play; the layout pass runs only when the document changes */
@@ -1996,7 +2055,8 @@ export default function Page() {
       await document.fonts?.ready;
       const el = document.querySelector<HTMLElement>(`[data-export="${f.id}"]`);
       if (!el) return;
-      const url = await toPng(el, { pixelRatio: 2, cacheBust: true, width: PHONE_W, height: PHONE_H });
+      const { w, h } = frameSizeOf(f);
+      const url = await toPng(el, { pixelRatio: 2, cacheBust: true, width: w, height: h });
       const a = document.createElement("a");
       a.href = url;
       a.download = `${f.name || "screen"}.png`;
@@ -2009,13 +2069,14 @@ export default function Page() {
   /** the runs of one screen drawn with plain divs: the export layer */
   const renderExport = (f: Frame) => {
     const gs = groups.filter((g) => frameOfGroup(g, frames, widths)?.id === f.id);
+    const { w, h } = frameSizeOf(f);
     return (
       <div
         data-export={f.id}
         style={{
           position: "relative",
-          width: PHONE_W,
-          height: PHONE_H,
+          width: w,
+          height: h,
           background: p[f.bg ?? "surface"],
           overflow: "hidden",
         }}
@@ -2214,10 +2275,11 @@ export default function Page() {
         const r = rects.find((x) => x.id === it.id);
         if (!f || !r) continue;
         const fr = frameRect(f);
-        const rightward = fr.l + PHONE_W / 2 >= (r.l + r.r) / 2;
+        const inset = isPhoneFrame(f) ? BEZEL : 0;
+        const rightward = (fr.l + fr.r) / 2 >= (r.l + r.r) / 2;
         const sx = rightward ? r.r : r.l;
         const sy = (r.t + r.b) / 2;
-        const tx = rightward ? fr.l - BEZEL : fr.r + BEZEL;
+        const tx = rightward ? fr.l - inset : fr.r + inset;
         const ty = clamp(sy, fr.t + 40, fr.b - 40);
         const dx = Math.max(60, Math.abs(tx - sx) * 0.5);
         const c1x = sx + (rightward ? dx : -dx);
@@ -2735,6 +2797,10 @@ export default function Page() {
                 frames.map((f) => {
                   const on = f.id === selectedFrameId;
                   const bg = p[f.bg ?? "surface"];
+                  const { w, h } = frameSizeOf(f);
+                  const phone = isPhoneFrame(f);
+                  const inset = phone ? BEZEL : 0;
+                  const radius = phone ? PHONE_R : DESKTOP_R;
                   return (
                     <div
                       key={f.id}
@@ -2745,8 +2811,8 @@ export default function Page() {
                         onPointerDown={(e) => onFramePointerDown(e, f)}
                         style={{
                           position: "absolute",
-                          left: -BEZEL,
-                          top: -BEZEL - FRAME_LABEL_H,
+                          left: -inset,
+                          top: -inset - FRAME_LABEL_H,
                           height: FRAME_LABEL_H,
                           display: "flex",
                           alignItems: "center",
@@ -2761,20 +2827,28 @@ export default function Page() {
                           fontFamily: "Roboto, system-ui, sans-serif",
                         }}
                       >
-                        <Icon name="smartphone" size={20} />
+                        <Icon name={phone ? "smartphone" : "desktop_windows"} size={20} />
                         {f.name || t("screen", lang)}
+                        <div onPointerDown={(e) => e.stopPropagation()} style={{ marginLeft: 4 }}>
+                          <FrameSizePicker
+                            frame={f}
+                            onChange={(preset) => setFramePreset(f.id, preset)}
+                            palette={p}
+                            compact
+                          />
+                        </div>
                       </div>
                       <div
                         onPointerDown={(e) => onFramePointerDown(e, f)}
                         style={{
                           position: "absolute",
-                          left: -BEZEL,
-                          top: -BEZEL,
+                          left: -inset,
+                          top: -inset,
                           overflow: "hidden",
-                          width: PHONE_W + BEZEL * 2,
-                          height: PHONE_H + BEZEL * 2,
-                          borderRadius: PHONE_R + BEZEL,
-                          background: p.inverseSurface,
+                          width: w + inset * 2,
+                          height: h + inset * 2,
+                          borderRadius: radius + inset,
+                          background: phone ? p.inverseSurface : bg,
                           boxShadow: on
                             ? `0 0 0 3px ${p.primary}, 0 18px 50px rgba(0,0,0,0.16)`
                             : "0 18px 50px rgba(0,0,0,0.14)",
@@ -2782,16 +2856,16 @@ export default function Page() {
                           transition: "box-shadow 120ms",
                         }}
                       >
-                        <AnimatePresence>{aiFrameId === f.id && <ThinkingRing key="ring" p={p} />}</AnimatePresence>
+                        <AnimatePresence>{aiFrameId === f.id && <ThinkingRing key="ring" p={p} frame={f} />}</AnimatePresence>
                         <div
                           data-screen={f.id}
                           style={{
                             position: "absolute",
-                            left: BEZEL,
-                            top: BEZEL,
-                            width: PHONE_W,
-                            height: PHONE_H,
-                            borderRadius: PHONE_R,
+                            left: inset,
+                            top: inset,
+                            width: w,
+                            height: h,
+                            borderRadius: radius,
                             background: bg,
                             overflow: "hidden",
                           }}
@@ -3220,6 +3294,7 @@ export default function Page() {
                 <FrameInspector
                   frame={selectedFrame}
                   palette={p}
+                  onSize={(preset) => setFramePreset(selectedFrame.id, preset)}
                   onChange={(patch) => patchFrame(selectedFrame.id, patch)}
                   onDelete={() => deleteFrame(selectedFrame.id)}
                   onDuplicate={() => duplicateFrame(selectedFrame.id)}
@@ -3243,6 +3318,7 @@ export default function Page() {
                     onCancel: cancelAi,
                   }}
                   item={selectedIds.length > 1 ? null : selected}
+                  frame={selectedPartFrame}
                   palette={p}
                   frames={frame === "phone" ? frames : []}
                   onChange={patchSelected}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1172,12 +1172,15 @@ export default function Page() {
         return;
       }
       if (d.fromPalette) snapshot();
-      const targetFrame = framesRef.current.find((f) => {
-        const r = frameRect(f);
-        const cx = rawX + sz.w / 2;
-        const cy = rawY + sz.h / 2;
-        return cx >= r.l && cx <= r.r && cy >= r.t && cy <= r.b;
-      });
+      const targetFrame =
+        frameRef.current === "phone"
+          ? framesRef.current.find((f) => {
+              const r = frameRect(f);
+              const cx = rawX + sz.w / 2;
+              const cy = rawY + sz.h / 2;
+              return cx >= r.l && cx <= r.r && cy >= r.t && cy <= r.b;
+            })
+          : undefined;
       const placedItem =
         targetFrame && (item.kind === "topAppBar" || item.kind === "bottomNav")
           ? { ...item, size: frameSizeOf(targetFrame).w }

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -594,7 +594,8 @@ export function Inspector({
   const mapWidthPreset = (v: number) =>
     v === PHONE_W ? frameSize.w : v === CONTENT_W ? contentWidth(frameSize.w) : v === HALF_W ? halfWidth(frameSize.w) : v;
   const mapHeightPreset = (v: number) => (v === PHONE_H ? frameSize.h : v === PHONE_H / 2 ? frameSize.h / 2 : v);
-  const widthMax = (max: number) => (max === PHONE_W ? frameSize.w : max);
+  const widthMax = (max: number) =>
+    max === PHONE_W ? frameSize.w : max === CONTENT_W ? contentWidth(frameSize.w) : max;
   const heightMax = (max: number) => (max === PHONE_H ? frameSize.h : max);
   const editOn = !!item.toggle && onTab;
   /* the on-state is edited through the same text / icon / style controls:

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -6,6 +6,7 @@ import {
   BACK_TARGET,
   CONTENT_W,
   Frame,
+  FramePreset,
   HALF_W,
   Item,
   KIND_SPEC,
@@ -23,7 +24,12 @@ import {
   VARIANTS,
   Variant,
   actionSlotsOf,
+  contentWidth,
   defaultTabsFor,
+  framePresetOf,
+  frameSizeOf,
+  halfWidth,
+  isPhoneFrame,
   toggleIcon,
   iconSlotsOf,
   setIconSlot,
@@ -124,12 +130,39 @@ export function VariantSwatch({
 
 const MAX_IMAGE_PX = 1200;
 
-/** hover text for a width preset that comes from the phone frame */
-export const widthPresetLabel = (v: number): string | undefined =>
-  v === PHONE_W ? t("screenWidth") : v === CONTENT_W ? t("contentWidth") : v === HALF_W ? t("halfWidth") : undefined;
+/** hover text for a width preset derived from the selected frame */
+export const widthPresetLabel = (v: number, frameWidth = PHONE_W): string | undefined =>
+  v === frameWidth ? t("screenWidth") : v === contentWidth(frameWidth) ? t("contentWidth") : v === halfWidth(frameWidth) ? t("halfWidth") : undefined;
 
-const heightPresetLabel = (v: number): string | undefined =>
-  v === PHONE_H ? t("screenHeight") : v === PHONE_H / 2 ? t("halfHeight") : undefined;
+const heightPresetLabel = (v: number, frameHeight = PHONE_H): string | undefined =>
+  v === frameHeight ? t("screenHeight") : v === frameHeight / 2 ? t("halfHeight") : undefined;
+
+export function FrameSizePicker({
+  frame,
+  palette: p,
+  onChange,
+  compact,
+}: {
+  frame: Frame;
+  palette: Palette;
+  onChange: (preset: FramePreset) => void;
+  compact?: boolean;
+}) {
+  const lang = useLang();
+  return (
+    <Segmented<FramePreset>
+      options={[
+        { key: "phone", icon: "smartphone", label: compact ? undefined : t("phoneFrame", lang), title: t("phoneFrame", lang) },
+        { key: "desktop", icon: "desktop_windows", label: compact ? undefined : t("desktopFrame", lang), title: t("desktopFrame", lang) },
+      ]}
+      value={framePresetOf(frame)}
+      onChange={onChange}
+      p={p}
+      height={compact ? 32 : 40}
+      grow={!compact}
+    />
+  );
+}
 
 /** Downscale a picked file so the document stays small enough for localStorage. */
 function readImage(file: File): Promise<string> {
@@ -203,7 +236,7 @@ function FrameChips({
     <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
       {chip(null, t("none", lang), "block")}
       {back && chip(BACK_TARGET, t("goBack", lang), "arrow_back")}
-      {frames.map((f) => chip(f.id, f.name || t("screen", lang), "smartphone"))}
+      {frames.map((f) => chip(f.id, f.name || t("screen", lang), isPhoneFrame(f) ? "smartphone" : "desktop_windows"))}
     </div>
   );
 }
@@ -280,6 +313,7 @@ export function FrameInspector({
   tidy,
   onTidy,
   ai,
+  onSize,
 }: {
   frame: Frame;
   palette: Palette;
@@ -294,6 +328,7 @@ export function FrameInspector({
   tidy: TidyState;
   onTidy: () => void;
   ai: AiHooks;
+  onSize: (preset: FramePreset) => void;
 }) {
   const lang = useLang();
   const [copied, setCopied] = useState(false);
@@ -344,14 +379,17 @@ export function FrameInspector({
           color: p.onSecondaryContainer,
         }}
       >
-        <Icon name="smartphone" size={20} />
+        <Icon name={isPhoneFrame(frame) ? "smartphone" : "desktop_windows"} size={20} />
         <span style={{ fontSize: 14, fontWeight: 600, flex: 1, minWidth: 0 }}>{t("screen", lang)}</span>
         <IconBtn icon="play_arrow" p={p} onClick={onPreview} title={t("previewFrom", lang)} size={32} fill />
         <IconBtn icon="content_copy" p={p} onClick={onDuplicate} title={t("duplicate", lang)} size={32} />
         <IconBtn icon="delete" p={p} danger onClick={onDelete} title={t("delete", lang)} size={32} />
       </div>
+      <Section id="frame-size" icon="aspect_ratio" title={t("frameSize", lang)} p={p}>
+        <FrameSizePicker frame={frame} palette={p} onChange={onSize} />
+      </Section>
       <Section id="frame-name" icon="label" title={t("name", lang)} p={p}>
-        <Field value={frame.name} onChange={(name) => onChange({ name })} placeholder={t("screenName", lang)} p={p} icon="smartphone" />
+        <Field value={frame.name} onChange={(name) => onChange({ name })} placeholder={t("screenName", lang)} p={p} icon={isPhoneFrame(frame) ? "smartphone" : "desktop_windows"} />
       </Section>
       <Section id="frame-note" icon="notes" title={t("description", lang)} p={p}>
         <AiField ai={ai} history={frame.noteHistory} onRestore={() => onChange(popHistory(frame.note, frame.noteHistory, "note", "noteHistory"))} p={p} value={frame.note ?? ""} onChange={(note) => onChange({ note: note || undefined })} placeholder={t("screenDescription", lang)} />
@@ -441,6 +479,7 @@ export function Inspector({
   item,
   palette: p,
   frames,
+  frame,
   onChange,
   onDelete,
   onDuplicate,
@@ -454,6 +493,8 @@ export function Inspector({
   item: Item | null;
   palette: Palette;
   frames: Frame[];
+  /** frame containing the selected part; its dimensions bound size controls */
+  frame?: Frame | null;
   onChange: (patch: Partial<Item>) => void;
   onDelete: () => void;
   onDuplicate: () => void;
@@ -549,6 +590,12 @@ export function Inspector({
   }
 
   const spec = KIND_SPEC[item.kind];
+  const frameSize = frame ? frameSizeOf(frame) : { w: PHONE_W, h: PHONE_H };
+  const mapWidthPreset = (v: number) =>
+    v === PHONE_W ? frameSize.w : v === CONTENT_W ? contentWidth(frameSize.w) : v === HALF_W ? halfWidth(frameSize.w) : v;
+  const mapHeightPreset = (v: number) => (v === PHONE_H ? frameSize.h : v === PHONE_H / 2 ? frameSize.h / 2 : v);
+  const widthMax = (max: number) => (max === PHONE_W ? frameSize.w : max);
+  const heightMax = (max: number) => (max === PHONE_H ? frameSize.h : max);
   const editOn = !!item.toggle && onTab;
   /* the on-state is edited through the same text / icon / style controls:
    * `shown` is what they display, `change` routes their patches into `toggle` */
@@ -971,7 +1018,7 @@ export function Inspector({
                   }
                   value={item.size ?? spec.defSize ?? spec.w}
                   min={spec.size.min}
-                  max={spec.size.max}
+                  max={widthMax(spec.size.max)}
                   step={spec.size.step}
                   onChange={(size) => onChange({ size })}
                   p={p}
@@ -979,13 +1026,13 @@ export function Inspector({
                 />
                 {spec.size.presets && (
                   <SizePresets
-                    values={spec.size.presets}
+                    values={[...new Set(spec.size.presets.map(mapWidthPreset))]}
                     value={item.size ?? spec.defSize ?? spec.w}
                     min={spec.size.min}
-                    max={spec.size.max}
+                    max={widthMax(spec.size.max)}
                     onChange={(size) => onChange({ size })}
                     p={p}
-                    labelOf={item.kind === "text" ? undefined : widthPresetLabel}
+                    labelOf={item.kind === "text" ? undefined : (v) => widthPresetLabel(v, frameSize.w)}
                   />
                 )}
               </>
@@ -997,20 +1044,20 @@ export function Inspector({
                   title={t("height", lang)}
                   value={item.size2 ?? spec.h}
                   min={spec.size2.min}
-                  max={spec.size2.max}
+                  max={heightMax(spec.size2.max)}
                   step={spec.size2.step}
                   onChange={(size2) => onChange({ size2 })}
                   p={p}
                 />
                 {spec.size2.presets && (
                   <SizePresets
-                    values={spec.size2.presets}
+                    values={[...new Set(spec.size2.presets.map(mapHeightPreset))]}
                     value={item.size2 ?? spec.h}
                     min={spec.size2.min}
-                    max={spec.size2.max}
+                    max={heightMax(spec.size2.max)}
                     onChange={(size2) => onChange({ size2 })}
                     p={p}
-                    labelOf={heightPresetLabel}
+                    labelOf={(v) => heightPresetLabel(v, frameSize.h)}
                   />
                 )}
               </>

--- a/components/Layers.tsx
+++ b/components/Layers.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { Reorder, useDragControls } from "motion/react";
-import { Frame, Group, KIND_SPEC, Palette } from "@/lib/tokens";
+import { Frame, Group, KIND_SPEC, Palette, isPhoneFrame } from "@/lib/tokens";
 import { Icon } from "./M3Node";
 import { IconBtn } from "./ui";
 import { t, useLang } from "@/lib/i18n";
@@ -154,7 +154,7 @@ export function LayersPanel({
                   flex: "0 0 auto",
                 }}
               >
-                <Icon name="smartphone" size={16} />
+                <Icon name={isPhoneFrame(f) ? "smartphone" : "desktop_windows"} size={16} />
                 {f.name || t("screen", lang)}
               </button>
             );

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -41,6 +41,8 @@ import { t, useLang } from "@/lib/i18n";
 
 const EASE = [0.2, 0, 0, 1] as const;
 const SLIDE_MS = 0.42;
+/** room reserved for the wide preview controls: panel, right margin and breathing space */
+const WIDE_CONTROL_SPACE = 220;
 
 type Anim = { t: Transition; back: boolean; /** the expressive motion scheme: springs instead of eased tweens */ spring?: boolean };
 
@@ -391,27 +393,56 @@ export function Preview({
 
   const top = stack[stack.length - 1];
   const current = frames.find((f) => f.id === top?.id) ?? frames[0];
+  const peekFrame = peek ? frames.find((f) => f.id === peek.frameId) : undefined;
   const { w: frameW, h: frameH } = current ? frameSizeOf(current) : { w: PHONE_W, h: PHONE_H };
   const phone = current ? isPhoneFrame(current) : true;
   const inset = phone ? BEZEL : 0;
   const radius = phone ? PHONE_R : DESKTOP_R;
   const outerW = frameW + inset * 2;
   const outerH = frameH + inset * 2;
+  const targetFrame = peekFrame ?? current;
+  const { w: targetFrameW, h: targetFrameH } = targetFrame ? frameSizeOf(targetFrame) : { w: frameW, h: frameH };
+  const targetPhone = targetFrame ? isPhoneFrame(targetFrame) : phone;
+  const targetInset = targetPhone ? BEZEL : 0;
+  const targetRadius = targetPhone ? PHONE_R : DESKTOP_R;
+  const targetOuterW = targetFrameW + targetInset * 2;
+  const targetOuterH = targetFrameH + targetInset * 2;
+
+  /* A tracked swipe can cross frame sizes. The shell and clipping viewport
+   * follow the gesture so the target is full-sized at the end, without a snap. */
+  const prog = useMotionValue(0);
+  const shellW = useTransform(prog, (v) => outerW + (targetOuterW - outerW) * v);
+  const shellH = useTransform(prog, (v) => outerH + (targetOuterH - outerH) * v);
+  const shellRadius = useTransform(prog, (v) => radius + inset + (targetRadius + targetInset - radius - inset) * v);
+  const screenW = useTransform(prog, (v) => frameW + (targetFrameW - frameW) * v);
+  const screenH = useTransform(prog, (v) => frameH + (targetFrameH - frameH) * v);
+  const screenInset = useTransform(prog, (v) => inset + (targetInset - inset) * v);
+  const screenRadius = useTransform(prog, (v) => radius + (targetRadius - radius) * v);
+  const shellBackground = useTransform(
+    prog,
+    [0, 1],
+    [phone ? p.inverseSurface : p[current?.bg ?? "surface"], targetPhone ? p.inverseSurface : p[targetFrame?.bg ?? "surface"]],
+  );
+  const maxOuterW = Math.max(outerW, targetOuterW);
+  const maxOuterH = Math.max(outerH, targetOuterH);
+  const shellLeft = useTransform(shellW, (v) => ((maxOuterW - v) * scale) / 2);
+  const shellTop = useTransform(shellH, (v) => ((maxOuterH - v) * scale) / 2);
 
   /* on a wide window the controls stand in a column at the right edge, clear of the phone;
    * on a phone they stay along the bottom, where the frame fills the width anyway */
   const [wide, setWide] = useState(false);
   useEffect(() => {
     const fit = () => {
-      setWide(window.innerWidth >= 720);
+      const isWide = window.innerWidth >= 720;
+      setWide(isWide);
       setScale(
-        Math.min(1.4, (window.innerHeight - 32) / outerH, (window.innerWidth - (window.innerWidth < 720 ? 16 : 240)) / outerW),
+        Math.min(1.4, (window.innerHeight - 32) / maxOuterH, (window.innerWidth - (isWide ? WIDE_CONTROL_SPACE + 16 : 16)) / maxOuterW),
       );
     };
     fit();
     window.addEventListener("resize", fit);
     return () => window.removeEventListener("resize", fit);
-  }, [outerH, outerW]);
+  }, [maxOuterH, maxOuterW]);
 
   const back = useCallback(() => {
     const s = stackRef.current;
@@ -445,11 +476,9 @@ export function Preview({
 
   const groupsFor = useCallback((f: Frame) => groupsInFrame(doc.groups, f, frames, widths), [doc.groups, frames, widths]);
   const groups = useMemo(() => (current ? groupsFor(current) : []), [current, groupsFor]);
-  const peekFrame = peek ? frames.find((f) => f.id === peek.frameId) : undefined;
   const peekGroups = useMemo(() => (peekFrame ? groupsFor(peekFrame) : []), [peekFrame, groupsFor]);
 
   /* ---- finger-tracked swipes: only the swipes the author set on the frame ---- */
-  const prog = useMotionValue(0);
   const axisMV = useMotionValue(0); // 0 = x, 1 = y
   const enterMV = useMotionValue(0);
   const exitMV = useMotionValue(0);
@@ -606,33 +635,35 @@ export function Preview({
         background: p.surfaceContainer,
         display: "grid",
         placeItems: "center",
+        boxSizing: "border-box",
+        paddingRight: wide ? WIDE_CONTROL_SPACE : 0,
       }}
     >
       <div
         style={{
-          width: outerW * scale,
-          height: outerH * scale,
+          width: maxOuterW * scale,
+          height: maxOuterH * scale,
           position: "relative",
-          marginBottom: 56,
+          marginBottom: wide ? 0 : 56,
         }}
       >
-        <div
+        <motion.div
           onPointerDown={onScreenPointerDown}
           style={{
             position: "absolute",
-            left: 0,
-            top: 0,
-            width: outerW,
-            height: outerH,
+            left: shellLeft,
+            top: shellTop,
+            width: shellW,
+            height: shellH,
             transform: `scale(${scale})`,
             touchAction: "none",
             transformOrigin: "0 0",
-            borderRadius: radius + inset,
-            background: phone ? p.inverseSurface : p[current.bg ?? "surface"],
+            borderRadius: shellRadius,
+            background: shellBackground,
             boxShadow: "0 30px 80px rgba(0,0,0,0.22)",
           }}
         >
-          <div
+          <motion.div
             onClickCapture={(e) => {
               if (swiped.current) {
                 e.stopPropagation();
@@ -641,11 +672,11 @@ export function Preview({
             }}
             style={{
               position: "absolute",
-              left: inset,
-              top: inset,
-              width: frameW,
-              height: frameH,
-              borderRadius: radius,
+              left: screenInset,
+              top: screenInset,
+              width: screenW,
+              height: screenH,
+              borderRadius: screenRadius,
               overflow: "hidden",
               background: p[current.bg ?? "surface"],
               fontFamily: fontFamilyOf(theme.font),
@@ -690,8 +721,8 @@ export function Preview({
                 <Screen frame={peekFrame} groups={peekGroups} {...screenProps} />
               </motion.div>
             )}
-          </div>
-        </div>
+          </motion.div>
+        </motion.div>
       </div>
 
       <div

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -8,6 +8,7 @@ import {
   Action,
   BACK_TARGET,
   BEZEL,
+  DESKTOP_R,
   Doc,
   Frame,
   GAP,
@@ -27,7 +28,9 @@ import {
   connectSpecOf,
   fontFamilyOf,
   freeRadii,
+  frameSizeOf,
   groupsInFrame,
+  isPhoneFrame,
   normalizeTheme,
   toggleIcon,
   uniformRadii,
@@ -388,6 +391,12 @@ export function Preview({
 
   const top = stack[stack.length - 1];
   const current = frames.find((f) => f.id === top?.id) ?? frames[0];
+  const { w: frameW, h: frameH } = current ? frameSizeOf(current) : { w: PHONE_W, h: PHONE_H };
+  const phone = current ? isPhoneFrame(current) : true;
+  const inset = phone ? BEZEL : 0;
+  const radius = phone ? PHONE_R : DESKTOP_R;
+  const outerW = frameW + inset * 2;
+  const outerH = frameH + inset * 2;
 
   /* on a wide window the controls stand in a column at the right edge, clear of the phone;
    * on a phone they stay along the bottom, where the frame fills the width anyway */
@@ -396,13 +405,13 @@ export function Preview({
     const fit = () => {
       setWide(window.innerWidth >= 720);
       setScale(
-        Math.min(1.4, (window.innerHeight - 32) / (PHONE_H + BEZEL * 2), (window.innerWidth - (window.innerWidth < 720 ? 16 : 240)) / (PHONE_W + BEZEL * 2)),
+        Math.min(1.4, (window.innerHeight - 32) / outerH, (window.innerWidth - (window.innerWidth < 720 ? 16 : 240)) / outerW),
       );
     };
     fit();
     window.addEventListener("resize", fit);
     return () => window.removeEventListener("resize", fit);
-  }, []);
+  }, [outerH, outerW]);
 
   const back = useCallback(() => {
     const s = stackRef.current;
@@ -464,7 +473,7 @@ export function Preview({
 
   const onScreenPointerDown = (e: React.PointerEvent) => {
     if (peekRef.current || e.button !== 0) return;
-    gesture.current = { id: e.pointerId, x0: e.clientX, y0: e.clientY, phase: "idle", size: PHONE_W, last: 0, lastT: e.timeStamp, vel: 0 };
+    gesture.current = { id: e.pointerId, x0: e.clientX, y0: e.clientY, phase: "idle", size: frameW, last: 0, lastT: e.timeStamp, vel: 0 };
     swiped.current = false;
   };
 
@@ -493,7 +502,8 @@ export function Preview({
         const sl = SLIDE_SPEC[pk.t]!;
         g.phase = "drag";
         g.dir = dir;
-        g.size = sl.axis === "x" ? PHONE_W : PHONE_H;
+        const { w, h } = frameSizeOf(cur);
+        g.size = sl.axis === "x" ? w : h;
         swiped.current = true;
         axisMV.set(sl.axis === "x" ? 0 : 1);
         enterMV.set(sl.enter);
@@ -600,8 +610,8 @@ export function Preview({
     >
       <div
         style={{
-          width: (PHONE_W + BEZEL * 2) * scale,
-          height: (PHONE_H + BEZEL * 2) * scale,
+          width: outerW * scale,
+          height: outerH * scale,
           position: "relative",
           marginBottom: 56,
         }}
@@ -612,13 +622,13 @@ export function Preview({
             position: "absolute",
             left: 0,
             top: 0,
-            width: PHONE_W + BEZEL * 2,
-            height: PHONE_H + BEZEL * 2,
+            width: outerW,
+            height: outerH,
             transform: `scale(${scale})`,
             touchAction: "none",
             transformOrigin: "0 0",
-            borderRadius: PHONE_R + BEZEL,
-            background: p.inverseSurface,
+            borderRadius: radius + inset,
+            background: phone ? p.inverseSurface : p[current.bg ?? "surface"],
             boxShadow: "0 30px 80px rgba(0,0,0,0.22)",
           }}
         >
@@ -631,11 +641,11 @@ export function Preview({
             }}
             style={{
               position: "absolute",
-              left: BEZEL,
-              top: BEZEL,
-              width: PHONE_W,
-              height: PHONE_H,
-              borderRadius: PHONE_R,
+              left: inset,
+              top: inset,
+              width: frameW,
+              height: frameH,
+              borderRadius: radius,
               overflow: "hidden",
               background: p[current.bg ?? "surface"],
               fontFamily: fontFamilyOf(theme.font),
@@ -733,7 +743,7 @@ export function Preview({
                 maxWidth: wide ? undefined : 200,
               }}
             >
-              <Icon name="smartphone" size={20} />
+              <Icon name={phone ? "smartphone" : "desktop_windows"} size={20} />
               <span style={{ ...label, flex: wide ? 1 : undefined, textAlign: "left" }}>{current.name || t("screen", lang)}</span>
               <Icon name={wide ? (picker ? "chevron_right" : "chevron_left") : picker ? "expand_more" : "expand_less"} size={18} />
             </button>
@@ -792,7 +802,9 @@ export function Preview({
                           textAlign: "left",
                         }}
                       >
-                        <span style={{ width: 18, display: "inline-flex" }}>{on && <Icon name="check" size={18} />}</span>
+                        <span style={{ width: 18, display: "inline-flex" }}>
+                          {on ? <Icon name="check" size={18} /> : <Icon name={isPhoneFrame(f) ? "smartphone" : "desktop_windows"} size={18} />}
+                        </span>
                         {f.name || t("screen", lang)}
                       </button>
                     );

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -190,6 +190,9 @@ const UI = {
   home: { ja: "ホーム", en: "Home", zh: "首页" },
   screenN: { ja: "画面", en: "Screen", zh: "屏幕" },
   copySuffix: { ja: " コピー", en: " copy", zh: " 副本" },
+  frameSize: { ja: "画面サイズ", en: "Frame size", zh: "画板尺寸" },
+  phoneFrame: { ja: "スマホ", en: "Phone", zh: "手机" },
+  desktopFrame: { ja: "デスクトップ", en: "Desktop", zh: "桌面" },
   // mobile
   mobileNote: { ja: "フル機能は PC のブラウザで使えます", en: "Full features on a desktop browser", zh: "完整功能请在电脑浏览器中使用" },
   addButton: { ja: "ボタンを追加", en: "Add button", zh: "添加按钮" },

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -33,7 +33,14 @@ const validGroup = (group: unknown) =>
   group.items.every(validItem);
 
 const validFrame = (frame: unknown) =>
-  isRecord(frame) && typeof frame.id === "string" && typeof frame.name === "string" && Number.isFinite(frame.x) && Number.isFinite(frame.y) && (frame.note === undefined || typeof frame.note === "string");
+  isRecord(frame) &&
+  typeof frame.id === "string" &&
+  typeof frame.name === "string" &&
+  Number.isFinite(frame.x) &&
+  Number.isFinite(frame.y) &&
+  (frame.w === undefined || (Number.isFinite(frame.w) && (frame.w as number) > 0)) &&
+  (frame.h === undefined || (Number.isFinite(frame.h) && (frame.h as number) > 0)) &&
+  (frame.note === undefined || typeof frame.note === "string");
 
 /** whether a parsed file has the shape of a document the editor can open */
 export const isProject = (value: unknown): value is Doc =>

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -11,13 +11,13 @@ import {
   Item,
   Kind,
   Palette,
-  PHONE_H,
   PHONE_W,
   SWIPE_DIRS,
   Theme,
   Variant,
   explodeGroup,
   frameOfGroup,
+  frameRect,
   groupBounds,
   normalizeTheme,
   paletteOf,
@@ -1016,7 +1016,7 @@ export function buildPrompt(doc: Doc, widths: Record<string, number>, onlyFrameI
       if (i > 0 || frames.length > 1) lines.push("");
       if (hasText(f.note)) lines.push(lang === "en" ? `${trimEnd(f.note!)}.` : `${trimEnd(f.note!)}。`);
       lines.push(ph.screenHead(q(f.name || ph.screen), f.bg && f.bg !== "surface" ? f.bg : undefined, gs.length > 0));
-      describeScreen(lines, gs, { l: f.x, t: f.y, r: f.x + PHONE_W, b: f.y + PHONE_H }, widths, lang);
+      describeScreen(lines, gs, frameRect(f), widths, lang);
     });
     if (loose.length && !only) {
       lines.push("");

--- a/lib/tidy.ts
+++ b/lib/tidy.ts
@@ -1,6 +1,6 @@
-import { Frame, Group, Item, PHONE_H, PHONE_MARGIN, PHONE_W, canJoin, connectSpecOf, frameOfGroup, groupBounds } from "./tokens";
+import { Frame, Group, Item, PHONE_MARGIN, canJoin, connectSpecOf, frameOfGroup, frameRect, groupBounds } from "./tokens";
 
-/* Rule-based layout for one phone screen. Nothing here is guessed by a model.
+/* Rule-based layout for one screen. Nothing here is guessed by a model.
  *
  * 1. Parts of one connectable family that sit next to each other fuse into a
  *    connected run, the same way the magnetic drop does: list items stacked in
@@ -149,7 +149,7 @@ const isAnchored = (u: Unit) => isTop(u) || isBottomBar(u) || isFloatingBottom(u
  *  Judged from the edges, so a part already on the margin reads the same way after tidying. */
 function align(bb: Rect, fr: Rect): "left" | "center" | "right" | "fill" {
   const w = bb.r - bb.l;
-  if (w >= PHONE_W - PHONE_MARGIN * 2 - 8) return "fill";
+  if (w >= fr.r - fr.l - PHONE_MARGIN * 2 - 8) return "fill";
   const near = PHONE_MARGIN + 12;
   const left = bb.l - fr.l <= near;
   const right = fr.r - bb.r <= near;
@@ -173,7 +173,9 @@ function gapBefore(prev: Unit[] | null, row: Unit[]): number {
 
 /** The tidied groups of the document, or null when `frame` is already tidy. */
 export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths: Record<string, number>): Group[] | null {
-  const fr: Rect = { l: frame.x, t: frame.y, r: frame.x + PHONE_W, b: frame.y + PHONE_H };
+  const fr: Rect = frameRect(frame);
+  const frameW = fr.r - fr.l;
+  const frameH = fr.b - fr.t;
   const mineIds = new Set(groups.filter((g) => frameOfGroup(g, frames, widths)?.id === frame.id).map((g) => g.id));
   if (!mineIds.size) return null;
 
@@ -193,13 +195,13 @@ export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths
   let bottom = fr.b;
   for (const u of units.filter(isBottomBar).sort((a, b) => b.bb.t - a.bb.t)) {
     bottom -= u.bb.b - u.bb.t;
-    target.set(u, { l: fr.l + Math.round((PHONE_W - (u.bb.r - u.bb.l)) / 2), t: bottom });
+    target.set(u, { l: fr.l + Math.round((frameW - (u.bb.r - u.bb.l)) / 2), t: bottom });
   }
   for (const u of units.filter(isFloatingBottom).sort((a, b) => b.bb.t - a.bb.t)) {
     const h = u.bb.b - u.bb.t;
     const w = u.bb.r - u.bb.l;
     bottom -= PHONE_MARGIN + h;
-    target.set(u, { l: fr.l + Math.round((PHONE_W - w) / 2), t: bottom });
+    target.set(u, { l: fr.l + Math.round((frameW - w) / 2), t: bottom });
   }
   let fabBottom = bottom;
   for (const u of units.filter(isFab).sort((a, b) => b.bb.t - a.bb.t)) {
@@ -209,7 +211,7 @@ export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths
     target.set(u, { l: fr.r - PHONE_MARGIN - w, t: fabBottom });
   }
   for (const u of units.filter(isOverlay)) {
-    target.set(u, { l: fr.l + Math.round((PHONE_W - (u.bb.r - u.bb.l)) / 2), t: fr.t + Math.round((PHONE_H - (u.bb.b - u.bb.t)) / 2) });
+    target.set(u, { l: fr.l + Math.round((frameW - (u.bb.r - u.bb.l)) / 2), t: fr.t + Math.round((frameH - (u.bb.b - u.bb.t)) / 2) });
   }
 
   /* everything else flows from the top on the layout margins, down to the bottom bars;
@@ -226,7 +228,7 @@ export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths
       const u = row[0];
       const w = u.bb.r - u.bb.l;
       const a = align(u.bb, fr);
-      const l = a === "left" ? fr.l + PHONE_MARGIN : a === "right" ? fr.r - PHONE_MARGIN - w : fr.l + Math.round((PHONE_W - w) / 2);
+      const l = a === "left" ? fr.l + PHONE_MARGIN : a === "right" ? fr.r - PHONE_MARGIN - w : fr.l + Math.round((frameW - w) / 2);
       target.set(u, { l, t: y });
     } else {
       const ws = row.map((u) => u.bb.r - u.bb.l);
@@ -235,12 +237,12 @@ export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths
       const gaps = row.slice(1).map((u, i) => (canJoin(row[i].probe, u.probe) ? APART_GAP_X : ROW_ITEM_GAP));
       const minPacked = total + gaps.reduce((s, g) => s + g, 0);
       const span = row[row.length - 1].bb.r - row[0].bb.l;
-      const inner = PHONE_W - PHONE_MARGIN * 2;
+      const inner = frameW - PHONE_MARGIN * 2;
       const spread = span >= inner * 0.7 && minPacked <= inner;
       const packed = spread ? inner : minPacked;
       const extra = spread ? (inner - minPacked) / gaps.length : 0;
       const a = spread ? "left" : align({ l: row[0].bb.l, t: 0, r: row[row.length - 1].bb.r, b: 0 }, fr);
-      let x = a === "right" ? fr.r - PHONE_MARGIN - packed : a === "center" ? fr.l + (PHONE_W - packed) / 2 : fr.l + PHONE_MARGIN;
+      let x = a === "right" ? fr.r - PHONE_MARGIN - packed : a === "center" ? fr.l + (frameW - packed) / 2 : fr.l + PHONE_MARGIN;
       row.forEach((u, i) => {
         const h = u.bb.b - u.bb.t;
         target.set(u, { l: Math.round(x), t: y + Math.round((rowH - h) / 2) });

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -21,16 +21,21 @@ export const SETTLE_MS = 340;
 export const PHONE_W = 412;
 export const PHONE_H = 892;
 export const PHONE_R = 40;
+export const DESKTOP_W = 1280;
+export const DESKTOP_H = 800;
+export const DESKTOP_R = 28;
 /** system insets: the status bar above a top app bar and the gesture area below a navigation bar.
  *  Both bars carry their inset as extra height so their background reaches the rounded screen edge. */
 export const STATUS_BAR_H = 24;
 export const NAV_BAR_H = 24;
 /** M3 layout margin: parts that are not edge-to-edge sit this far from the screen edge */
 export const PHONE_MARGIN = 16;
+export const contentWidth = (width: number) => width - PHONE_MARGIN * 2;
+export const halfWidth = (width: number) => (contentWidth(width) - PHONE_MARGIN) / 2;
 /** width of a part that spans the screen with a margin on both sides */
-export const CONTENT_W = PHONE_W - PHONE_MARGIN * 2;
+export const CONTENT_W = contentWidth(PHONE_W);
 /** width of one of two parts sharing a row, with a margin-sized gutter between them */
-export const HALF_W = (CONTENT_W - PHONE_MARGIN) / 2;
+export const HALF_W = halfWidth(PHONE_W);
 /** width presets offered in the inspector: two columns, with margins, edge-to-edge */
 export const WIDTH_PRESETS = [HALF_W, CONTENT_W, PHONE_W];
 /** height presets for free-form boxes: half the screen, the whole screen */
@@ -573,23 +578,25 @@ export const KIND_SPEC: Record<Kind, KindSpec> = {
     noun: "トップアプリバー",
     category: "navigation",
     paletteIcon: "toolbar",
-    w: 412,
+    w: PHONE_W,
     h: 64 + STATUS_BAR_H,
     radius: 0,
     hasVariant: false,
     hasLabel: true,
     hasSupporting: false,
     hasIcon: true,
+    size: { min: 200, max: PHONE_W, step: 4, icon: "width", presets: WIDTH_PRESETS },
     defLabel: "タイトル",
     defIcon: "menu",
     defIcon2: "more_vert",
+    defSize: PHONE_W,
   },
   bottomNav: {
     label: "Navigation Bar",
     noun: "ナビゲーションバー",
     category: "navigation",
     paletteIcon: "bottom_navigation",
-    w: 412,
+    w: PHONE_W,
     h: 80 + NAV_BAR_H,
     radius: 0,
     hasVariant: false,
@@ -597,8 +604,10 @@ export const KIND_SPEC: Record<Kind, KindSpec> = {
     hasSupporting: false,
     hasIcon: false,
     hasTabs: true,
+    size: { min: 200, max: PHONE_W, step: 4, icon: "width", presets: WIDTH_PRESETS },
     defLabel: "",
     defIcon: null,
+    defSize: PHONE_W,
   },
   searchBar: {
     label: "Search Bar",
@@ -1162,6 +1171,9 @@ export type Frame = {
   name: string;
   x: number;
   y: number;
+  /** dimensions are optional so documents saved before desktop frames remain phone-sized */
+  w?: number;
+  h?: number;
   bg?: ColorToken;
   /** what this screen is for, in the author's words; goes into the prompt */
   note?: string;
@@ -1171,7 +1183,19 @@ export type Frame = {
   swipe?: Partial<Record<SwipeDir, string>>;
 };
 
-export const frameRect = (f: Frame) => ({ l: f.x, t: f.y, r: f.x + PHONE_W, b: f.y + PHONE_H });
+export type FramePreset = "phone" | "desktop";
+export const frameSizeOf = (f: Frame) => ({ w: f.w ?? PHONE_W, h: f.h ?? PHONE_H });
+export const isPhoneFrame = (f: Frame) => {
+  const { w, h } = frameSizeOf(f);
+  return w === PHONE_W && h === PHONE_H;
+};
+export const framePresetOf = (f: Frame): FramePreset => (isPhoneFrame(f) ? "phone" : "desktop");
+export const framePresetPatch = (preset: FramePreset): Pick<Frame, "w" | "h"> =>
+  preset === "desktop" ? { w: DESKTOP_W, h: DESKTOP_H } : { w: undefined, h: undefined };
+export const frameRect = (f: Frame) => {
+  const { w, h } = frameSizeOf(f);
+  return { l: f.x, t: f.y, r: f.x + w, b: f.y + h };
+};
 
 export type Placed = { item: Item; index: number; x: number; y: number; w: number; h: number };
 
@@ -1392,6 +1416,8 @@ export function sizeOf(it: Item, widths: Record<string, number>) {
     case "image":
       return { w: n, h: n };
     case "searchBar":
+    case "topAppBar":
+    case "bottomNav":
     case "listItem":
     case "textField":
     case "slider":


### PR DESCRIPTION
## What and why

Implements the Stage 1 scope agreed in #7.

- Adds optional frame width and height fields while keeping existing documents phone-sized by default.
- Adds Phone (412 x 892) and Desktop (1280 x 800) presets to frame labels and the Frame Inspector.
- Allows phone and desktop frames to coexist in one document.
- Renders desktop frames as plain rounded rectangles without a phone bezel.
- Routes frame dimensions through canvas rendering, snapping, fit, placement, preview scaling, PNG export, prompt bounds, and tidy layout.
- Stretches Top App Bar and Navigation Bar parts to the frame width when the frame preset changes.
- Makes phone-based size limits and presets follow the selected part frame.

This intentionally leaves the Stage 2 and Stage 3 work from #7 out of scope: navigation rail/adaptive behavior and desktop-specific prompt wording.

## How I checked it

- [x] npm run typecheck passes
- [x] npm run build passes
- [x] New UI strings exist in Japanese, English and Chinese
- [x] Tried phone and desktop frames together in the editor
- [x] Verified desktop preview scaling and checked the browser console for errors

## Screenshots

Manually verified phone and desktop frames side by side in the editor. No screenshot is attached.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phone and desktop frame size presets so frames are no longer locked to phone dimensions.

Previously every frame was a 412 x 892 phone screen with a bezel. Now frames can be switched between Phone and Desktop presets from the frame label or the Frame Inspector, and both sizes can coexist in one document. Desktop frames render as plain rounded rectangles without the phone bezel. Existing documents keep their phone-sized frames because the new width and height fields are optional.

**New Features**
- Top App Bar and Navigation Bar parts stretch to the frame width when the preset changes or when dropped into a frame.
- Part size limits and presets in the Inspector follow the selected part's frame.
- Frame dimensions now flow through canvas rendering, snapping, fit, placement, preview scaling, PNG export, prompt bounds, and tidy layout.

<sup>Written for commit 7f0f219769a58ea6de41f47a77160ba165eef319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

