### PR TITLE
Hide the canvas until its initial fit completes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -317,6 +317,8 @@ export default function Page() {
 
   /* ---------- editor ui ---------- */
   const [view, setView] = useState<View>({ x: 0, y: 0, z: 1 });
+  /** Keep the server-rendered world hidden until its first fit has completed. */
+  const [viewReady, setViewReady] = useState(false);
   /** screens ease to their new place and size for a moment after one changes size */
   const [easing, setEasing] = useState(false);
   /** the canvas transform eases while the camera glides to or from a screen */
@@ -582,7 +584,10 @@ export default function Page() {
         frameRef.current = "phone";
       }
       ensureFrameRef.current();
-      queueMicrotask(() => fitRef.current());
+      queueMicrotask(() => {
+        fitRef.current();
+        setViewReady(true);
+      });
     };
     apply();
     mq.addEventListener("change", apply);
@@ -2828,6 +2833,7 @@ export default function Page() {
                 transformOrigin: "0 0",
                 transition: cameraEasing ? `transform ${SETTLE_MS}ms cubic-bezier(0.2, 0, 0, 1)` : undefined,
                 willChange: "transform",
+                visibility: viewReady ? "visible" : "hidden",
                 fontFamily: fontFamilyOf(theme.font),
               }}
             >


### PR DESCRIPTION
## What and why

On a hard load, the statically rendered canvas world initially used the default camera `{ x: 0, y: 0, z: 1 }`. The first screen could therefore flash at full scale against the left side before the client restored or fitted the view.

Keep the canvas world hidden through the initial server render and hydration, then reveal it immediately after the first fit completes. The editor shell remains visible, and the change does not affect document data, persistence, or layout formats.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] New or changed UI strings and prompt text exist in Japanese, English and Chinese (not applicable: no strings changed)
- [x] Tried it in the editor and at a 390 × 844 phone viewport

I also checked the server-rendered state with JavaScript blocked, a fresh browser session, reloads, and the 1918 × 1078 viewport from the original recording.

## Screenshots

Before: the canvas could briefly appear at the default position and scale before fitting.

After: the editor shell renders immediately, while the canvas world becomes visible only in its fitted position.
