### PR TITLE
Add Korean localization and fix language switching across editor workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,11 +29,11 @@ is stored in the browser.
 | Area | Files |
 |---|---|
 | Part definitions, sizes, corners, theme | `lib/tokens.ts` |
-| UI strings and part defaults (ja / en / zh) | `lib/i18n.ts` |
+| UI strings and part defaults (ja / en / zh / ko) | `lib/i18n.ts` |
 | Drawing a part | `components/M3Node.tsx` |
 | Editing a part (desktop / phone) | `components/Inspector.tsx`, `components/Mobile.tsx` |
 | Tap-through preview | `components/Preview.tsx` |
-| Prompt text (ja / en / zh) | `lib/prompt.ts` |
+| Prompt text (ja / en / zh / ko) | `lib/prompt.ts` |
 | Color schemes | `lib/color.ts`, `components/ColorPanel.tsx` |
 | Shape / type / motion panels | `components/ThemePanel.tsx` |
 | The editor itself | `app/page.tsx` |
@@ -43,15 +43,15 @@ is stored in the browser.
 A new kind touches all of these; the existing kinds are the reference:
 
 1. `Kind`, `KIND_SPEC`, `KIND_ORDER` and, if needed, `sizeOf` / `baseRadii` / `iconSlotsOf` in `lib/tokens.ts`
-2. `KIND_TEXT` for all three languages in `lib/i18n.ts`
+2. `KIND_TEXT` for all four languages in `lib/i18n.ts`
 3. Rendering in `components/M3Node.tsx` (and `MEASURED` / `NO_BOX` when it applies)
-4. The item sentence in `itemJa`, `itemEn`, `itemZh` and a `STYLE_NOTES` entry per language in `lib/prompt.ts`
+4. The item sentence in `itemJa`, `itemEn`, `itemZh`, `itemKo` and a `STYLE_NOTES` entry per language in `lib/prompt.ts`
 5. Any special editor in `components/Inspector.tsx`; tap targets in `components/Preview.tsx` if it is tappable
 
 ## Conventions
 
 - Code comments are in English. UI strings and prompt text exist in Japanese,
-  English and Chinese; a string added in one language must be added in all three.
+  English, Chinese and Korean; a string added in one language must be added in all four.
 - Use the standard Material 3 Expressive values (sizes, corners, tokens) and name
   them the way Material does. When in doubt, link the Material page in your PR.
 - Keep the editor chrome and the parts on separate paths: parts are drawn from the
@@ -73,7 +73,7 @@ A new kind touches all of these; the existing kinds are the reference:
 - バグ報告や小さな修正は Issue または PR を直接どうぞ。
 - 新しい部品やパネル、プロンプトの文言など大きめの変更は、先に Issue で相談してください。
 - 質問やアイデアは Discussions へ。
-- コードのコメントは英語で書きます。UI の文言とプロンプト文は日本語・英語・中国語の 3 言語すべてに追加してください。
+- コードのコメントは英語で書きます。UI の文言とプロンプト文は日本語・英語・中国語・韓国語の 4 言語すべてに追加してください。
 - PR の前に `npm run typecheck` と `npm run build` を通してください。CI でも同じものが走ります。
 - 貢献したコードは MIT ライセンスで公開されます。
 
@@ -82,6 +82,6 @@ A new kind touches all of these; the existing kinds are the reference:
 - Bug 报告和小修改可以直接提 Issue 或 PR。
 - 新组件、新面板、提示词措辞等较大的改动，请先开 Issue 讨论。
 - 提问和想法请到 Discussions。
-- 代码注释用英文。UI 文字和提示词需同时提供日文、英文、中文三种语言。
+- 代码注释用英文。UI 文字和提示词需同时提供日文、英文、中文、韩文四种语言。
 - 提交 PR 前请运行 `npm run typecheck` 和 `npm run build`，CI 会执行同样的检查。
 - 贡献的代码以 MIT 许可证发布。

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Works with any AI coding tool that takes a prompt, such as Claude Code, Codex, G
 - **Toggle buttons** – any button can flip on tap, changing its icon and style.
 - **Layers and groups** – a layers panel lists the z-order of each screen; drag or use the arrows to bring parts forward or send them back. Select several parts and group them to keep their overlap and move them as one. The prompt describes overlaps and side-by-side rows explicitly so the generated layout keeps them.
 - **Theme** – the four M3 Expressive axes in one panel. Color: seven presets or one seed color that becomes a full Material 3 scheme you can fine-tune, light / dark, three contrast levels and a dynamic-color switch (match the phone wallpaper). Shape: square, rounded or full corners for every part at once. Type: Roboto, Roboto Flex, Roboto Serif or the system font, with the emphasized styles. Motion: the standard or the expressive spring scheme, which also drives the preview.
-- **Prompt output** – the whole design (or a single screen) becomes a concise natural-language prompt in Japanese, English or Chinese, including your own notes on what each part does. Pick Android (the default) or the web as the target and the prompt asks for the matching stack.
+- **Prompt output** – the whole design (or a single screen) becomes a concise natural-language prompt in Japanese, English, Chinese or Korean, including your own notes on what each part does. Pick Android (the default) or the web as the target and the prompt asks for the matching stack.
 - **Tidy** – one button snaps bars to the edges, the FAB to the corner, joins neighbouring list items and buttons, and stacks the rest on 16dp margins. Press it again to undo.
 - **Optional AI helper** – bring your own key (OpenAI, Claude, Gemini or DeepSeek) and let the model write a part's behavior note or a screen's description, in your language. Each rewrite can be undone. The key stays in your browser and the request goes straight to the provider; there is no server in between.
 - **Export** – copy the prompt (edit it by hand first if you like) or save a screen as a PNG.
@@ -50,7 +50,7 @@ Works with any AI coding tool that takes a prompt, such as Claude Code, Codex, G
 <table>
   <tr>
     <td width="50%"><img src="docs/preview.png" alt="Tap-through preview" /><br /><sub>Preview: tap a part and the linked screen slides in.</sub></td>
-    <td width="50%"><img src="docs/prompt.png" alt="Prompt panel" /><br /><sub>Prompt: the design as a concise brief, in Japanese or English.</sub></td>
+    <td width="50%"><img src="docs/prompt.png" alt="Prompt panel" /><br /><sub>Prompt: the design as a concise brief in the selected language.</sub></td>
   </tr>
 </table>
 
@@ -81,7 +81,7 @@ The app is a static Next.js export. To host it under a sub-path (for example a G
 
 ## Contributing
 
-Bug reports, part requests and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) explains the setup, the conventions (English comments, three languages for every string) and where each kind of change lives. Questions go to [Discussions](https://github.com/lnkiai/m3e-canvas/discussions).
+Bug reports, part requests and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) explains the setup, the conventions (English comments, four languages for every string) and where each kind of change lives. Questions go to [Discussions](https://github.com/lnkiai/m3e-canvas/discussions).
 
 ## Credits
 
@@ -122,7 +122,7 @@ Claude Code、Codex、Gemini CLI、Cursor など、プロンプトを受け取�
 - **切り替えボタン** – ボタンをタップでオン／オフが切り替わるトグルにして、オン時のアイコンとスタイルを指定できます。
 - **レイヤーとグループ** – 画面ごとの重なり順をレイヤーパネルで確認し、ドラッグや矢印で前後を入れ替えられます。複数選択してグループ化すると、重なりを保ったまま一緒に動かせます。プロンプトには重なりや横並びが明示され、生成されるレイアウトが崩れにくくなります。
 - **テーマ** – M3 Expressive の 4 つの軸を 1 つのパネルで。カラーは 7 種のプリセットか、ベース色 1 つから Material 3 のスキーム全体を生成して微調整でき、ライト／ダーク、3 段階のコントラスト、壁紙に合わせるダイナミックカラーも指定できます。シェイプは全部品の角丸をスクエア／標準／フルでまとめて切り替え。タイポグラフィは Roboto、Roboto Flex、Roboto Serif、システムフォントと強調スタイル。モーションはスタンダード／エクスプレッシブで、プレビューの遷移にも反映されます。
-- **プロンプト出力** – デザイン全体、または 1 画面だけを、日本語・英語・中国語の簡潔な文章にします。部品ごとの「振る舞い」メモもそのまま入ります。実装先は Android（既定）と Web から選べ、プロンプトはそれに合った技術で書かれます。
+- **プロンプト出力** – デザイン全体、または 1 画面だけを、日本語・英語・中国語・韓国語の簡潔な文章にします。部品ごとの「振る舞い」メモもそのまま入ります。実装先は Android（既定）と Web から選べ、プロンプトはそれに合った技術で書かれます。
 - **整える** – ボタンひとつでバーを端に、FAB を隅に寄せ、隣り合うリスト項目やボタンをつなげ、残りを余白 16dp で積み直します。もう一度押すと元に戻ります。
 - **AI 補助（任意）** – 自分のキー（OpenAI、Claude、Gemini、DeepSeek）を入れると、部品の動作や画面の説明を UI の言語で書いてもらえます。書き換えは元に戻せます。キーはブラウザ内にだけ保存され、リクエストはプロバイダへ直接送られます（間にサーバーはありません）。
 - **書き出し** – プロンプトのコピー（手で編集してからも可）、画面の PNG 保存。
@@ -172,7 +172,7 @@ MIT © lnkiai
 - **切换按钮** – 任何按钮都可以做成点击切换的按钮，开启时改变文字、图标和样式。
 - **图层与编组** – 图层面板显示每个屏幕的层叠顺序，可拖动或用箭头调整前后；多选后可编组，保持叠放关系并一起移动。提示词会明确写出叠放和横向排列，让生成的布局不走样。
 - **主题** – 在一个面板里调整 M3 Expressive 的四个维度。配色：七套预设，或用一个基准色生成整套 Material 3 配色并微调，支持浅色／深色、三档对比度和动态配色（跟随手机壁纸）。形状：一次切换所有组件的圆角（方形／圆角／全圆）。字体：Roboto、Roboto Flex、Roboto Serif 或系统字体，并可开启强调样式。动效：标准或富有表现力的弹簧方案，同时作用于预览过渡。
-- **提示词输出** – 整个设计（或单个屏幕）会变成简洁的自然语言提示词，支持日文、英文和中文，并包含你为每个组件写的行为说明。目标平台可选 Android（默认）或 Web，提示词会相应地要求对应的技术栈。
+- **提示词输出** – 整个设计（或单个屏幕）会变成简洁的自然语言提示词，支持日文、英文、中文和韩文，并包含你为每个组件写的行为说明。目标平台可选 Android（默认）或 Web，提示词会相应地要求对应的技术栈。
 - **整理** – 一键把栏贴到边缘、FAB 放到角落、相邻的列表项和按钮连成一组，其余组件按 16dp 边距重新堆叠。再按一次即可撤销。
 - **AI 辅助（可选）** – 填入自己的密钥（OpenAI、Claude、Gemini 或 DeepSeek），让模型用界面语言写出组件的行为或屏幕的说明。每次改写都可以撤销。密钥只保存在浏览器中，请求直接发送给服务商，中间没有服务器。
 - **导出** – 复制提示词（也可先手动编辑），或把屏幕保存为 PNG。

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,14 +33,14 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&family=Roboto:wght@400;500;600;700&display=swap"
         />
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400..700,0..1,0&display=block"
         />
       </head>
-      <body style={{ fontFamily: "Roboto, system-ui, sans-serif" }}>{children}</body>
+      <body style={{ fontFamily: "Roboto, 'Noto Sans KR', system-ui, sans-serif" }}>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,7 +93,7 @@ import { MotionPanel, ShapePanel, TypePanel } from "@/components/ThemePanel";
 import { ThemeContext, ensureFontLoaded } from "@/lib/theme";
 import { BottomSheet, MobileActionBar, MobileInspector, MobileLang, MobileSettings } from "@/components/Mobile";
 import { ConfirmDialog, IconBtn, Segmented } from "@/components/ui";
-import { Lang, LangContext, isLang, setGlobalLang, t } from "@/lib/i18n";
+import { Lang, LangContext, SEED_TEXT, getLang, isLang, setGlobalLang, t, translateDefaultFrameName, translateDefaultText } from "@/lib/i18n";
 
 /** the dragged part's own travel: a little lag reads as weight */
 const CARRY = {
@@ -170,6 +170,21 @@ type Snapshot = { groups: Group[]; frames: Frame[] };
 /** a screen changing size eases the way a settling part does */
 const SIZE_TRANSITION = `width ${SETTLE_MS}ms cubic-bezier(0.2, 0, 0, 1), height ${SETTLE_MS}ms cubic-bezier(0.2, 0, 0, 1), border-radius ${SETTLE_MS}ms cubic-bezier(0.2, 0, 0, 1)`;
 
+function translateSnapshot(snap: Snapshot, lang: Lang): Snapshot {
+  return {
+    groups: snap.groups.map((group) => ({
+      ...group,
+      items: group.items.map((item) => ({
+        ...item,
+        label: translateDefaultText(item.label, item.kind, "label", lang),
+        ...(item.supporting !== undefined && { supporting: translateDefaultText(item.supporting, item.kind, "supporting", lang) }),
+        ...(item.tabs && { tabs: item.tabs.map((tab) => ({ ...tab, label: translateDefaultText(tab.label, item.kind, "tab", lang) })) }),
+      })),
+    })),
+    frames: snap.frames.map((frame) => ({ ...frame, name: translateDefaultFrameName(frame.name, lang) })),
+  };
+}
+
 const SEED_FRAMES: Frame[] = [{ id: "seedF1", name: "Home", x: 0, y: 0 }];
 
 /** Documents saved before the bars grew their system insets have the navigation
@@ -187,23 +202,24 @@ function migrateGroups(groups: Group[], frames: Frame[]): Group[] {
 }
 
 /** Seed ids are deterministic so server and client render the same markup. */
-const seed = (): Group[] => {
+const seed = (lang: Lang = getLang()): Group[] => {
+  const text = SEED_TEXT[lang];
   let n = 0;
   const sid = () => `seed${++n}`;
   const mk = (k: Kind) => ({ ...makeItem(k), id: sid() });
   const bar = mk("topAppBar");
   const a = mk("button");
   const b = mk("button");
-  a.label = "お気に入り";
+  a.label = text.favorite;
   a.icon = "star";
-  b.label = "共有";
+  b.label = text.share;
   b.icon = "share";
   b.variant = "tonal";
-  const rows = ["受信トレイ", "スター付き", "アーカイブ"].map((t, i) => {
+  const rows = [text.inbox, text.starred, text.archive].map((t, i) => {
     const it = mk("listItem");
     it.label = t;
     it.icon = ["inbox", "star", "archive"][i];
-    it.supporting = "サブテキスト";
+    it.supporting = text.supporting;
     return it;
   });
   const nav = mk("bottomNav");
@@ -224,17 +240,18 @@ const seed = (): Group[] => {
 };
 
 /** The phone version starts with buttons only: that is all it edits. */
-const mobileSeed = (): Group[] => {
+const mobileSeed = (lang: Lang = getLang()): Group[] => {
+  const text = SEED_TEXT[lang];
   const mk = (k: Kind) => makeItem(k);
   const a = mk("button");
   const b = mk("button");
   const c = mk("button");
-  a.label = "お気に入り";
+  a.label = text.favorite;
   a.icon = "star";
-  b.label = "共有";
+  b.label = text.share;
   b.icon = "share";
   b.variant = "tonal";
-  c.label = "はじめる";
+  c.label = text.start;
   c.icon = "arrow_forward";
   return [
     { id: uid(), x: PHONE_MARGIN, y: 120, axis: "x", items: [a, b] },
@@ -301,6 +318,16 @@ export default function Page() {
   const patchTheme = (patch: Partial<Theme>) => setTheme((t) => ({ ...t, ...patch }));
   const [frame, setFrame] = useState<FrameMode>("phone");
   const [lang, setLang] = useState<Lang>("ja");
+  const changeLanguage = (next: Lang) => {
+    setGlobalLang(next);
+    initialLangRef.current = next;
+    setLang(next);
+    const translated = translateSnapshot({ groups: groupsRef.current, frames: framesRef.current }, next);
+    setGroups(translated.groups);
+    setFrames(translated.frames);
+    pastRef.current = pastRef.current.map((snap) => translateSnapshot(snap, next));
+    futureRef.current = futureRef.current.map((snap) => translateSnapshot(snap, next));
+  };
   const [isMobile, setIsMobile] = useState(false);
   const [sheet, setSheet] = useState<"edit" | "settings" | "lang" | null>(null);
   const [confirmClear, setConfirmClear] = useState(false);
@@ -399,7 +426,8 @@ export default function Page() {
   /** groups that must reposition without animating on the next render */
   const instantRef = useRef<Set<string>>(new Set());
   const loadedRef = useRef(false);
-  /** whether a saved document existed, so the phone seed only applies to a fresh start */
+  const initialLangRef = useRef<Lang>("ja");
+  /** A saved document or the first viewport initialization prevents later reseeding. */
   const hadDocRef = useRef(false);
 
   /* ---------- history ---------- */
@@ -494,6 +522,7 @@ export default function Page() {
         applyDoc(JSON.parse(d) as Partial<Doc>, false);
         // frame mode is decided by the device (media-query effect), not restored
       }
+      let initialLang: Lang = "ja";
       const u = localStorage.getItem(UI_KEY);
       if (u) {
         const ui = JSON.parse(u);
@@ -504,12 +533,21 @@ export default function Page() {
         if (ui.rightW) setRightW(ui.rightW);
         if (Array.isArray(ui.favorites)) setFavorites(ui.favorites);
         if (ui.mode) setMode(ui.mode);
-        if (isLang(ui.lang)) setLang(ui.lang);
+        if (isLang(ui.lang)) {
+          initialLang = ui.lang;
+          setLang(ui.lang);
+        }
       } else {
         const nl = (navigator.language ?? "").toLowerCase();
-        if (nl.startsWith("zh")) setLang("zh");
-        else if (!nl.startsWith("ja")) setLang("en");
+        initialLang = nl.startsWith("zh") ? "zh" : nl.startsWith("ko") ? "ko" : nl.startsWith("ja") ? "ja" : "en";
+        setLang(initialLang);
         queueMicrotask(() => fitRef.current());
+      }
+      setGlobalLang(initialLang);
+      initialLangRef.current = initialLang;
+      if (!d) {
+        setGroups(seed(initialLang));
+        setFrames([{ ...SEED_FRAMES[0], name: t("home", initialLang) }]);
       }
     } catch {}
     setAiSettings(loadAiSettings());
@@ -517,7 +555,6 @@ export default function Page() {
   }, []);
 
   useEffect(() => {
-    setGlobalLang(lang);
     document.documentElement.lang = lang;
   }, [lang]);
 
@@ -573,10 +610,11 @@ export default function Page() {
         setSheet(null);
         if (!hadDocRef.current) {
           hadDocRef.current = true;
-          setGroups(mobileSeed());
-          setFrames([{ id: uid(), name: t("home"), x: 0, y: 0 }]);
+          setGroups(mobileSeed(initialLangRef.current));
+          setFrames([{ id: uid(), name: t("home", initialLangRef.current), x: 0, y: 0 }]);
         }
       }
+      hadDocRef.current = true;
       if (frameRef.current !== "phone") {
         setFrame("phone");
         frameRef.current = "phone";
@@ -648,7 +686,10 @@ export default function Page() {
   });
 
   useEffect(() => {
-    document.fonts?.ready.then(() => setWidths({}));
+    const refreshWidths = () => setWidths({});
+    document.fonts?.ready.then(refreshWidths);
+    document.fonts?.addEventListener("loadingdone", refreshWidths);
+    return () => document.fonts?.removeEventListener("loadingdone", refreshWidths);
   }, []);
 
   const sizeRef = useCallback((it: Item) => sizeOf(it, widthsRef.current), []);
@@ -2689,7 +2730,7 @@ export default function Page() {
                 </div>
               ))}
               <div style={{ flex: 1 }} onClick={() => !leftOpen && setLeftOpen(true)} />
-              <LangMenu p={p} onLang={setLang} side="right" size={44} />
+              <LangMenu p={p} onLang={changeLanguage} side="right" size={44} />
               <GitHubLink p={p} size={44} />
             </div>
             {leftOpen && (
@@ -2863,7 +2904,7 @@ export default function Page() {
                           cursor: handMode ? "grab" : "move",
                           userSelect: "none",
                           whiteSpace: "nowrap",
-                          fontFamily: "Roboto, system-ui, sans-serif",
+                          fontFamily: "Roboto, 'Noto Sans KR', system-ui, sans-serif",
                         }}
                       >
                         <div onPointerDown={(e) => e.stopPropagation()}>
@@ -3233,7 +3274,7 @@ export default function Page() {
                   palette={p}
                   lang={lang}
                   onLang={(l) => {
-                    setLang(l);
+                    changeLanguage(l);
                     setSheet(null);
                   }}
                 />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -323,6 +323,14 @@ export default function Page() {
     initialLangRef.current = next;
     setLang(next);
     const translated = translateSnapshot({ groups: groupsRef.current, frames: framesRef.current }, next);
+    const tidy = tidyRef.current;
+    if (tidy) {
+      tidyRef.current = tidy.after === groupsRef.current ? {
+        ...tidy,
+        before: translateSnapshot({ groups: tidy.before, frames: framesRef.current }, next).groups,
+        after: translated.groups,
+      } : null;
+    }
     setGroups(translated.groups);
     setFrames(translated.frames);
     pastRef.current = pastRef.current.map((snap) => translateSnapshot(snap, next));

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -40,44 +40,45 @@ import { Icon } from "./M3Node";
 import { ButtonRun, CornerIcon, Field, IconBtn, Section, Segmented, SizePresets, Slider, TidyButton, TidyState, Toggle, TokenChips } from "./ui";
 import { AiWriteBtn } from "./AiPanel";
 import { popHistory } from "@/lib/ai";
-import { SWIPE_TEXT, t, useLang } from "@/lib/i18n";
+import { KIND_TEXT, SWIPE_TEXT, TRANSITION_TEXT, t, useLang } from "@/lib/i18n";
 
 export function variantsOf(kind: Kind): { key: Variant; label: string }[] {
+  const variants = VARIANTS.map((v) => ({ ...v, label: t(v.key) }));
   switch (kind) {
     case "card":
       return [
-        { key: "tonal", label: "Filled" },
-        { key: "elevated", label: "Elevated" },
-        { key: "outlined", label: "Outlined" },
+        { key: "tonal", label: t("filled") },
+        { key: "elevated", label: t("elevated") },
+        { key: "outlined", label: t("outlined") },
       ];
     case "textField":
       return [
-        { key: "outlined", label: "Outlined" },
-        { key: "filled", label: "Filled" },
+        { key: "outlined", label: t("outlined") },
+        { key: "filled", label: t("filled") },
       ];
     case "chip":
       return [
-        { key: "outlined", label: "Outlined" },
-        { key: "tonal", label: "Elevated" },
+        { key: "outlined", label: t("outlined") },
+        { key: "tonal", label: t("elevated") },
       ];
     case "fab":
     case "extendedFab":
     case "fabMenu":
-      return VARIANTS.filter((v) => v.key !== "text" && v.key !== "elevated" && v.key !== "outlined");
+      return variants.filter((v) => v.key !== "text" && v.key !== "elevated" && v.key !== "outlined");
     case "splitButton":
-      return VARIANTS.filter((v) => v.key !== "text");
+      return variants.filter((v) => v.key !== "text");
     case "toolbar":
       return [
-        { key: "tonal", label: "Standard" },
-        { key: "filled", label: "Vibrant" },
+        { key: "tonal", label: t("standard") },
+        { key: "filled", label: t("vibrant") },
       ];
     case "iconButton":
-      return VARIANTS.filter((v) => v.key !== "elevated" && v.key !== "text").concat({
+      return variants.filter((v) => v.key !== "elevated" && v.key !== "text").concat({
         key: "text",
-        label: "Standard",
+        label: t("standard"),
       });
     default:
-      return VARIANTS;
+      return variants;
   }
 }
 
@@ -250,9 +251,10 @@ function FrameChips({
 }
 
 function TransitionPicker({ value, onChange, p }: { value: Transition; onChange: (t: Transition) => void; p: Palette }) {
+  const lang = useLang();
   return (
     <Segmented<Transition>
-      options={TRANSITIONS.map((tr) => ({ key: tr.key, icon: tr.icon, title: tr.label }))}
+      options={TRANSITIONS.map((tr) => ({ key: tr.key, icon: tr.icon, title: TRANSITION_TEXT[lang][tr.key] }))}
       value={value}
       onChange={onChange}
       p={p}
@@ -699,7 +701,7 @@ export function Inspector({
         }}
       >
         <Icon name={spec.paletteIcon} size={20} />
-        <span style={{ fontSize: 14, fontWeight: 600, flex: 1, minWidth: 0 }}>{spec.label}</span>
+        <span style={{ fontSize: 14, fontWeight: 600, flex: 1, minWidth: 0 }}>{KIND_TEXT[lang][item.kind]?.noun ?? spec.label}</span>
         <IconBtn icon="content_copy" p={p} onClick={onDuplicate} title={t("duplicateKey", lang)} size={32} />
         <IconBtn icon="delete" p={p} danger onClick={onDelete} title={t("delete", lang)} size={32} />
       </div>

--- a/components/Layers.tsx
+++ b/components/Layers.tsx
@@ -5,7 +5,7 @@ import { Reorder, useDragControls } from "motion/react";
 import { Frame, Group, KIND_SPEC, Palette, isPhoneFrame } from "@/lib/tokens";
 import { Icon } from "./M3Node";
 import { IconBtn } from "./ui";
-import { t, useLang } from "@/lib/i18n";
+import { KIND_TEXT, t, useLang } from "@/lib/i18n";
 
 function Row({
   g,
@@ -30,12 +30,13 @@ function Row({
   const controls = useDragControls();
   const first = g.items[0];
   const spec = KIND_SPEC[first.kind];
+  const noun = KIND_TEXT[lang][first.kind]?.noun ?? spec.label;
   const label =
     g.free
       ? `${t("group", lang)} × ${g.items.length}`
       : g.items.length > 1
-      ? `${spec.label} × ${g.items.length}`
-      : first.label.trim() || (first.kind === "iconButton" || first.kind === "fab" ? (first.icon ?? spec.label) : spec.label);
+      ? `${noun} × ${g.items.length}`
+      : first.label.trim() || (first.kind === "iconButton" || first.kind === "fab" ? (first.icon ?? noun) : noun);
   return (
     <Reorder.Item
       value={g.id}

--- a/components/Mobile.tsx
+++ b/components/Mobile.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { motion, useDragControls } from "motion/react";
 import { CONTRASTS, Contrast, FONTS, Item, KIND_SPEC, NavTab, PALETTES, Palette, SHAPES, ShapeScale, Theme, defaultTabsFor, iconSlotsOf, setIconSlot } from "@/lib/tokens";
 import { ensureFontLoaded } from "@/lib/theme";
-import { LANGS, Lang, t, useLang } from "@/lib/i18n";
+import { KIND_TEXT, LANGS, Lang, t, useLang } from "@/lib/i18n";
 import { IconPicker } from "./IconPicker";
 import { Icon } from "./M3Node";
 import { VariantSwatch, variantsOf } from "./Inspector";
@@ -145,7 +145,7 @@ export function MobileInspector({
         >
           <Icon name={spec.paletteIcon} size={22} />
         </div>
-        <span style={{ fontSize: 16, fontWeight: 700, color: p.onSurface, flex: 1 }}>{spec.label}</span>
+        <span style={{ fontSize: 16, fontWeight: 700, color: p.onSurface, flex: 1 }}>{KIND_TEXT[lang][item.kind]?.noun ?? spec.label}</span>
         <IconBtn icon="content_copy" p={p} onClick={onDuplicate} title={t("duplicate", lang)} size={44} />
         <IconBtn icon="delete" p={p} danger onClick={onDelete} title={t("delete", lang)} size={44} />
         <IconBtn icon="check" p={p} on onClick={onClose} title={t("done", lang)} size={44} />

--- a/components/PartsPalette.tsx
+++ b/components/PartsPalette.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { CATEGORIES, KIND_ORDER, KIND_SPEC, Kind, Palette } from "@/lib/tokens";
+import { CATEGORIES, KIND_ORDER, KIND_SPEC, Category, Kind, Palette } from "@/lib/tokens";
 import { Icon } from "./M3Node";
-import { t, useLang } from "@/lib/i18n";
+import { KIND_TEXT, t, useLang } from "@/lib/i18n";
 import { Field, Section, Tile } from "./ui";
+
+const CATEGORY_TEXT = {
+  ja: { actions: "操作", navigation: "ナビゲーション", containment: "コンテナ", inputs: "入力", content: "コンテンツ", progress: "進捗" },
+  zh: { actions: "操作", navigation: "导航", containment: "容器", inputs: "输入", content: "内容", progress: "进度" },
+  ko: { actions: "동작", navigation: "내비게이션", containment: "컨테이너", inputs: "입력", content: "콘텐츠", progress: "진행 상태" },
+} satisfies Record<string, Record<Category, string>>;
 
 export function PartsPalette({
   palette: p,
@@ -21,15 +27,16 @@ export function PartsPalette({
 }) {
   const lang = useLang();
   const [q, setQ] = useState("");
+  const labelOf = (k: Kind) => lang === "en" ? KIND_SPEC[k].label : KIND_TEXT[lang][k]?.noun ?? KIND_SPEC[k].label;
 
   const filtered = useMemo(() => {
     const s = q.trim().toLowerCase();
     if (!s) return KIND_ORDER;
     return KIND_ORDER.filter((k) => {
       const sp = KIND_SPEC[k];
-      return sp.label.toLowerCase().includes(s) || sp.noun.includes(s) || k.toLowerCase().includes(s);
+      return labelOf(k).toLowerCase().includes(s) || sp.label.toLowerCase().includes(s) || sp.noun.includes(s) || k.toLowerCase().includes(s);
     });
-  }, [q]);
+  }, [q, lang]);
 
   const tile = (k: Kind) => {
     const s = KIND_SPEC[k];
@@ -37,7 +44,7 @@ export function PartsPalette({
       <Tile
         key={k}
         icon={s.paletteIcon}
-        label={s.label}
+        label={labelOf(k)}
         p={p}
         onPointerDown={(e) => onPartPointerDown(e, k)}
         starred={favorites.includes(k)}
@@ -75,7 +82,7 @@ export function PartsPalette({
           </div>
         ) : (
           CATEGORIES.map((c) => (
-            <Section key={c.key} id={`cat:${c.key}`} icon={c.icon} title={c.label} p={p}>
+            <Section key={c.key} id={`cat:${c.key}`} icon={c.icon} title={lang === "en" ? c.label : CATEGORY_TEXT[lang][c.key]} p={p}>
               <div style={grid}>{KIND_ORDER.filter((k) => KIND_SPEC[k].category === c.key).map(tile)}</div>
             </Section>
           ))

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { COLOR_TOKENS, ColorToken, Palette, R_INNER, clamp } from "@/lib/tokens";
 import { AnimatePresence, motion } from "motion/react";
-import { t, useLang } from "@/lib/i18n";
+import { COLOR_TOKEN_TEXT, t, useLang } from "@/lib/i18n";
 import { Icon } from "./M3Node";
 
 export function IconBtn({
@@ -700,12 +700,13 @@ export function TokenChips({
       )}
       {COLOR_TOKENS.map((t) => {
         const on = !noneOn && t.key === value;
+        const label = lang === "en" ? t.label : COLOR_TOKEN_TEXT[lang][t.key];
         return (
           <button
             key={t.key}
             onClick={() => onChange(t.key)}
-            title={t.label}
-            aria-label={t.label}
+            title={label}
+            aria-label={label}
             aria-pressed={on}
             className="m3-press"
             style={{

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -135,7 +135,7 @@ function parseJsonObject(text: string): Record<string, unknown> {
 
 /* ---------- actions ---------- */
 
-const LANG_NAME: Record<Lang, string> = { ja: "Japanese", en: "English", zh: "Simplified Chinese" };
+const LANG_NAME: Record<Lang, string> = { ja: "Japanese", en: "English", zh: "Simplified Chinese", ko: "Korean" };
 
 const hasText = (v?: string | null) => !!v && v.trim().length > 0;
 

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -2,13 +2,14 @@
 
 import { createContext, useContext } from "react";
 
-export type Lang = "ja" | "en" | "zh";
+export type Lang = "ja" | "en" | "zh" | "ko";
 export const LANGS: { key: Lang; label: string }[] = [
   { key: "ja", label: "日本語" },
   { key: "en", label: "English" },
   { key: "zh", label: "中文" },
+  { key: "ko", label: "한국어" },
 ];
-export const isLang = (v: unknown): v is Lang => v === "ja" || v === "en" || v === "zh";
+export const isLang = (v: unknown): v is Lang => v === "ja" || v === "en" || v === "zh" || v === "ko";
 
 /* A module-level copy lets non-React helpers (item defaults, prompt text)
  * follow the language without threading it through every call. */
@@ -21,7 +22,49 @@ export const setGlobalLang = (l: Lang) => {
 export const LangContext = createContext<Lang>("ja");
 export const useLang = () => useContext(LangContext);
 
+export const SEED_TEXT: Record<Lang, { favorite: string; share: string; inbox: string; starred: string; archive: string; supporting: string; start: string }> = {
+  ja: { favorite: "お気に入り", share: "共有", inbox: "受信トレイ", starred: "スター付き", archive: "アーカイブ", supporting: "サブテキスト", start: "はじめる" },
+  en: { favorite: "Favorite", share: "Share", inbox: "Inbox", starred: "Starred", archive: "Archive", supporting: "Supporting text", start: "Get started" },
+  zh: { favorite: "收藏", share: "分享", inbox: "收件箱", starred: "已加星标", archive: "归档", supporting: "辅助文本", start: "开始" },
+  ko: { favorite: "즐겨찾기", share: "공유", inbox: "받은편지함", starred: "별표 표시", archive: "보관함", supporting: "보조 텍스트", start: "시작하기" },
+};
+
+/** ponytail: matches defaults by text; add provenance if authored copies must be distinguished. */
+export function translateDefaultText(value: string, kind: string, field: "label" | "supporting" | "tab", lang: Lang): string {
+  for (const { key: from } of LANGS) {
+    if (field === "tab") {
+      const labels = (l: Lang) => kind === "tabs" ? TAB_LABELS[l] : (kind === "fabMenu" ? FAB_MENU_TABS[l] : NAV_TABS[l]).map((tab) => tab.label);
+      const index = labels(from).indexOf(value);
+      if (index >= 0) return labels(lang)[index] ?? value;
+    } else {
+      if (value && value === KIND_TEXT[from][kind]?.[field]) return KIND_TEXT[lang][kind]?.[field] ?? value;
+      const keys: (keyof typeof SEED_TEXT.en)[] = field === "supporting" ? ["supporting"] : kind === "button" ? ["favorite", "share", "start"] : kind === "listItem" ? ["inbox", "starred", "archive"] : [];
+      for (const key of keys) {
+        if (value === SEED_TEXT[from][key]) return SEED_TEXT[lang][key];
+      }
+    }
+  }
+  return value;
+}
+
 type Str = { ja: string; en: string; zh: string };
+
+export function translateDefaultFrameName(name: string, lang: Lang): string {
+  for (const { key } of LANGS) {
+    if (name === t("home", key)) return t("home", lang);
+    const prefix = `${t("screenN", key)} `;
+    if (name.startsWith(prefix) && /^\d+$/.test(name.slice(prefix.length))) {
+      return `${t("screenN", lang)} ${name.slice(prefix.length)}`;
+    }
+  }
+  return name;
+}
+
+export const COLOR_TOKEN_TEXT = {
+  ja: { surface: "サーフェス", surfaceContainerLow: "コンテナ（低）", surfaceContainer: "コンテナ", surfaceContainerHigh: "コンテナ（高）", surfaceContainerHighest: "コンテナ（最高）", primaryContainer: "プライマリコンテナ", secondaryContainer: "セカンダリコンテナ", tertiaryContainer: "ターシャリコンテナ", primary: "プライマリ", inverseSurface: "反転サーフェス" },
+  zh: { surface: "表面", surfaceContainerLow: "低层容器", surfaceContainer: "容器", surfaceContainerHigh: "高层容器", surfaceContainerHighest: "最高层容器", primaryContainer: "主色容器", secondaryContainer: "次色容器", tertiaryContainer: "第三色容器", primary: "主色", inverseSurface: "反色表面" },
+  ko: { surface: "표면", surfaceContainerLow: "낮은 컨테이너", surfaceContainer: "컨테이너", surfaceContainerHigh: "높은 컨테이너", surfaceContainerHighest: "가장 높은 컨테이너", primaryContainer: "주 색상 컨테이너", secondaryContainer: "보조 색상 컨테이너", tertiaryContainer: "세 번째 색상 컨테이너", primary: "주 색상", inverseSurface: "반전 표면" },
+};
 
 const UI = {
   // panels
@@ -97,6 +140,12 @@ const UI = {
   noIcon: { ja: "アイコンなし", en: "No icon", zh: "无图标" },
   searchIcons: { ja: "アイコンを検索", en: "Search icons", zh: "搜索图标" },
   style: { ja: "スタイル", en: "Style", zh: "样式" },
+  filled: { ja: "塗りつぶし", en: "Filled", zh: "填充" },
+  tonal: { ja: "トーナル", en: "Tonal", zh: "色调" },
+  elevated: { ja: "浮き上がり", en: "Elevated", zh: "凸起" },
+  outlined: { ja: "枠線", en: "Outlined", zh: "描边" },
+  standard: { ja: "標準", en: "Standard", zh: "标准" },
+  vibrant: { ja: "鮮やか", en: "Vibrant", zh: "鲜艳" },
   state: { ja: "状態", en: "State", zh: "状态" },
   selected: { ja: "選択", en: "Selected", zh: "已选中" },
   handle: { ja: "ハンドル（ボトムシート）", en: "Handle (bottom sheet)", zh: "拖动条（底部面板）" },
@@ -280,7 +329,53 @@ const UI = {
 
 export type UIKey = keyof typeof UI;
 
-export const t = (key: UIKey, lang: Lang = current): string => UI[key][lang];
+const KO: Record<UIKey, string> = {
+  frameSize: "화면 크기", phoneFrame: "휴대전화", desktopFrame: "데스크톱", columnWidth: "휴대전화 한 화면 너비", cornerLeft: "왼쪽 모서리", cornerRight: "오른쪽 모서리",
+  filled: "채움", tonal: "색조", elevated: "그림자", outlined: "윤곽선", standard: "표준", vibrant: "선명함",
+  parts: "부품", layers: "레이어", edit: "편집", prompt: "프롬프트", closePanel: "패널 닫기",
+  search: "검색", favorites: "즐겨찾기", addFavorite: "즐겨찾기에 추가", removeFavorite: "즐겨찾기에서 제거", clear: "지우기", language: "언어",
+  select: "선택 (V)", hand: "손 도구 (H / Space)", blank: "빈 캔버스", phone: "휴대전화 화면", addFrame: "화면 추가", preview: "미리보기 (P)",
+  zoomIn: "확대 (+)", zoomOut: "축소 (-)", fit: "전체 맞춤 (0)", undo: "실행 취소 (Ctrl+Z)", redo: "다시 실행 (Ctrl+Shift+Z)",
+  clearAll: "모두 지우기", clearAllTitle: "캔버스를 비울까요?", clearAllBody: "모든 화면과 부품을 삭제합니다. 실행 취소(Ctrl+Z)로 복원할 수 있습니다.",
+  screen: "화면", screenName: "화면 이름", name: "이름", background: "배경", export: "내보내기", project: "프로젝트",
+  saveProject: "프로젝트 저장", openProject: "프로젝트 열기", replaceProjectTitle: "이 프로젝트를 열까요?",
+  replaceProject: "현재 캔버스가 교체되며 실행 취소(Ctrl+Z)로 되돌릴 수 없습니다. 먼저 저장하는 것이 안전합니다.",
+  invalidProject: "프로젝트 파일을 열 수 없습니다.", copied: "복사됨", saveImage: "이미지로 저장", saving: "저장 중…", previewFrom: "이 화면부터 미리보기",
+  duplicate: "복제", duplicateKey: "복제 (Ctrl+D)", delete: "삭제 (Delete)", deleteSelection: "선택 항목 삭제",
+  text: "텍스트", label: "레이블", bold: "굵게", action: "동작", supporting: "보조 텍스트", tabs: "항목", changeIcon: "아이콘 변경",
+  image: "이미지", pickImage: "이미지 선택", removeImage: "이미지 제거", icon: "아이콘", noIcon: "아이콘 없음", searchIcons: "아이콘 검색",
+  style: "스타일", state: "상태", selected: "선택됨", handle: "핸들(하단 시트)", on: "켜짐", container: "컨테이너", wavy: "물결 모양", determinate: "확정형",
+  size: "크기", width: "너비", height: "높이", fontSize: "글자 크기", cornerRadius: "모서리 둥글기", cornerTop: "위쪽 모서리", cornerBottom: "아래쪽 모서리",
+  screenWidth: "화면 너비", contentWidth: "좌우 16dp 여백", halfWidth: "한 행의 절반(2열)", screenHeight: "화면 높이", halfHeight: "화면의 절반",
+  tapTo: "탭하여 이동", none: "없음", goBack: "뒤로", swipeTo: "스와이프하여 이동", toggle: "토글 버튼", toggleHint: "탭할 때 켜짐/꺼짐 전환",
+  thumbCheck: "켜졌을 때 체크 아이콘 표시", behavior: "동작", whenPressed: "눌렀을 때…", whatItDoes: "이 부품의 동작…", removeLink: "링크 제거",
+  group: "그룹", makeGroup: "그룹화", ungroup: "그룹 해제", selectedParts: "개 선택됨", groupHint: "겹침을 유지한 채 하나의 레이어처럼 함께 이동합니다",
+  iconBackground: "아이콘 배경", noBackground: "배경 없음", normalState: "기본", onState: "켜짐", onStateHint: "켜졌을 때의 텍스트, 아이콘, 스타일",
+  groupEditNote: "안쪽 부품을 편집하려면 그룹을 해제하세요", openPanel: "패널 열기", colors: "색상", templates: "팔레트", customColor: "사용자 지정",
+  seedColor: "기준 색상", seedHint: "색상 하나로 전체 Material 3 색상 구성을 만듭니다. 세부 조정에서 개별 색상도 바꿀 수 있습니다.",
+  useThis: "이 색상 사용", fineTune: "세부 조정", dynamicColor: "동적 색상",
+  dynamicOnHint: "여기 표시된 색상은 편집기 전용입니다. 실제 기기에서는 배경화면 색상을 사용합니다.",
+  dynamicOffHint: "켜면 실제 기기는 배경화면 색상을 사용하고 여기의 색상은 대체 색상이 됩니다.", closeBtn: "닫기", screens: "화면 선택",
+  layerUp: "앞으로 가져오기", layerDown: "뒤로 보내기", noLayers: "이 화면에는 아직 부품이 없습니다",
+  brief: "이 앱에 대한 설명…", appName: "앱 이름", targetPlatform: "구현 대상", targetAndroid: "Android 네이티브 앱으로 만들기",
+  targetWeb: "브라우저에서 실행되는 웹 앱으로 만들기", copyPrompt: "프롬프트 복사", back: "뒤로", close: "닫기 (Esc)", cancel: "취소", ok: "확인",
+  leading: "앞쪽", trailing: "뒤쪽", home: "홈", screenN: "화면", copySuffix: " 복사본", mobileNote: "전체 기능은 데스크톱 브라우저에서 사용할 수 있습니다",
+  addButton: "버튼 추가", done: "완료", theme: "테마", settings: "테마 및 설정", shape: "모양", typography: "글꼴", motion: "모션",
+  brightness: "밝기", light: "라이트", dark: "다크", contrast: "대비", bothModes: "둘 다", contrastStandard: "표준", contrastMedium: "중간", contrastHigh: "높음",
+  shapeScale: "모서리 둥글기", shapeSquare: "사각형", shapeRounded: "둥근형", shapeFull: "완전 둥근형",
+  shapeHint: "모든 부품의 기본 모서리를 한 번에 바꿉니다. 부품에 직접 입력한 반경은 유지됩니다.", fontFamily: "글꼴", emphasized: "강조 스타일",
+  emphasizedHint: "제목과 레이블에 더 굵은 M3 Expressive 스타일을 사용합니다.", motionScheme: "모션 방식", motionStandard: "표준", motionExpressive: "익스프레시브",
+  motionHint: "익스프레시브는 통통 튀는 스프링 효과입니다. 미리보기 화면 전환과 프롬프트에 반영됩니다.", tryIt: "탭하여 확인",
+  tidy: "정리", tidyUndo: "정리 실행 취소", tidyDone: "이미 정돈되어 있습니다", description: "설명", screenDescription: "이 화면의 용도",
+  ai: "AI", promptReset: "생성된 프롬프트로 되돌리기", aiWriteShort: "AI로 작성", aiWrite: "AI에게 작성 맡기기", aiSettings: "AI 설정",
+  aiProvider: "제공업체", aiBaseUrl: "기본 URL", aiModel: "모델 ID", aiKey: "API 키", aiGetKey: "키 받기",
+  aiKeyHint: "키는 이 브라우저에만 저장되며 제공업체로 직접 전송됩니다.", aiRestore: "AI 수정본과 원본 전환", aiApplied: "적용됨",
+  aiSelectScreen: "먼저 화면을 선택하세요", aiNoKey: "AI 탭에 키를 입력하면 사용할 수 있습니다", aiError: "AI 요청에 실패했습니다",
+  aiErrorRefusal: "모델이 답변을 거부했습니다", aiErrorJson: "모델의 응답을 읽을 수 없습니다", aiErrorModel: "모델 ID를 입력하세요",
+  aiErrorInsecure: "기본 URL은 https를 사용하거나 localhost를 가리켜야 합니다", aiErrorNetwork: "연결할 수 없습니다. URL, 네트워크 및 서버의 CORS 설정을 확인하세요",
+};
+
+export const t = (key: UIKey, lang: Lang = current): string => (lang === "ko" ? KO[key] : UI[key][lang]);
 
 /* ---- part defaults and nouns ---- */
 
@@ -384,6 +479,38 @@ export const KIND_TEXT: Record<
     radio: { noun: "单选按钮", label: "选项" },
     badge: { noun: "徽标", label: "3" },
   },
+  ko: {
+    box: { noun: "상자" },
+    button: { noun: "버튼", label: "버튼" },
+    iconButton: { noun: "아이콘 버튼" },
+    fab: { noun: "FAB" },
+    extendedFab: { noun: "확장 FAB", label: "만들기" },
+    chip: { noun: "칩", label: "칩" },
+    topAppBar: { noun: "상단 앱 바", label: "제목" },
+    bottomNav: { noun: "내비게이션 바" },
+    navRail: { noun: "내비게이션 레일" },
+    searchBar: { noun: "검색창", label: "검색" },
+    card: { noun: "카드", label: "카드 제목", supporting: "보조 텍스트가 여기에 표시됩니다." },
+    listItem: { noun: "목록 항목", label: "목록 항목", supporting: "보조 텍스트" },
+    dialog: { noun: "대화상자", label: "확인", supporting: "계속하시겠습니까?" },
+    snackbar: { noun: "스낵바", label: "저장됨", supporting: "실행 취소" },
+    textField: { noun: "텍스트 입력란", label: "레이블" },
+    switch: { noun: "스위치", label: "알림" },
+    checkbox: { noun: "체크박스", label: "동의합니다" },
+    slider: { noun: "슬라이더" },
+    text: { noun: "텍스트", label: "제목" },
+    image: { noun: "이미지" },
+    divider: { noun: "구분선" },
+    loadingIndicator: { noun: "로딩 표시기" },
+    linearProgress: { noun: "선형 진행 표시기" },
+    circularProgress: { noun: "원형 진행 표시기" },
+    splitButton: { noun: "분할 버튼", label: "보내기" },
+    fabMenu: { noun: "FAB 메뉴" },
+    toolbar: { noun: "도구 모음" },
+    tabs: { noun: "탭" },
+    radio: { noun: "라디오 버튼", label: "옵션" },
+    badge: { noun: "배지", label: "3" },
+  },
 };
 
 /** default labels of a tab row */
@@ -391,6 +518,7 @@ export const TAB_LABELS: Record<Lang, string[]> = {
   ja: ["おすすめ", "フォロー中", "人気", "新着", "保存済み"],
   en: ["For you", "Following", "Trending", "New", "Saved"],
   zh: ["推荐", "关注", "热门", "最新", "已保存"],
+  ko: ["추천", "팔로잉", "인기", "새 항목", "저장됨"],
 };
 
 /** default entries of a FAB menu */
@@ -416,6 +544,13 @@ export const FAB_MENU_TABS: Record<Lang, { icon: string; label: string }[]> = {
     { icon: "attach_file", label: "文件" },
     { icon: "event", label: "日程" },
   ],
+  ko: [
+    { icon: "edit", label: "메모" },
+    { icon: "photo_camera", label: "사진" },
+    { icon: "mic", label: "오디오" },
+    { icon: "attach_file", label: "파일" },
+    { icon: "event", label: "일정" },
+  ],
 };
 
 export const NAV_TABS: Record<Lang, { icon: string; label: string }[]> = {
@@ -436,6 +571,12 @@ export const NAV_TABS: Record<Lang, { icon: string; label: string }[]> = {
     { icon: "search", label: "搜索" },
     { icon: "favorite", label: "收藏" },
     { icon: "settings", label: "设置" },
+  ],
+  ko: [
+    { icon: "home", label: "홈" },
+    { icon: "search", label: "검색" },
+    { icon: "favorite", label: "저장됨" },
+    { icon: "settings", label: "설정" },
   ],
 };
 
@@ -467,10 +608,20 @@ export const TRANSITION_TEXT: Record<Lang, Record<string, string>> = {
     expand: "放大",
     none: "无动画",
   },
+  ko: {
+    slide: "오른쪽에서 슬라이드",
+    slideLeft: "왼쪽에서 슬라이드",
+    slideUp: "아래에서 슬라이드",
+    slideDown: "위에서 슬라이드",
+    fade: "페이드",
+    expand: "확대",
+    none: "애니메이션 없음",
+  },
 };
 
 export const SWIPE_TEXT: Record<Lang, Record<string, string>> = {
   ja: { left: "左へスワイプ", right: "右へスワイプ", up: "上へスワイプ", down: "下へスワイプ" },
   en: { left: "swiping left", right: "swiping right", up: "swiping up", down: "swiping down" },
   zh: { left: "向左滑动", right: "向右滑动", up: "向上滑动", down: "向下滑动" },
+  ko: { left: "왼쪽으로 스와이프", right: "오른쪽으로 스와이프", up: "위로 스와이프", down: "아래로 스와이프" },
 };

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -29,6 +29,7 @@ const VARIANT_TEXT: Record<Lang, Record<Variant, string>> = {
   ja: { filled: "塗りつぶし", tonal: "トーナル", elevated: "エレベーテッド", outlined: "アウトライン", text: "テキスト" },
   en: { filled: "filled", tonal: "tonal", elevated: "elevated", outlined: "outlined", text: "text" },
   zh: { filled: "填充", tonal: "色调", elevated: "浮起", outlined: "描边", text: "文字" },
+  ko: { filled: "채움", tonal: "토널", elevated: "돌출", outlined: "윤곽선", text: "텍스트" },
 };
 
 const hasText = (s?: string | null) => !!s && s.trim().length > 0;
@@ -286,7 +287,64 @@ function itemZh(it: Item): string {
   }
 }
 
-const itemText = (it: Item, lang: Lang) => (lang === "ja" ? itemJa(it) : lang === "zh" ? itemZh(it) : itemEn(it));
+function itemKo(it: Item): string {
+  const q = qe;
+  const v = VARIANT_TEXT.ko[it.variant];
+  const noun = KIND_TEXT.ko[it.kind]?.noun ?? it.kind;
+  switch (it.kind) {
+    case "button": return `${hasText(it.label) ? q(it.label) : "레이블 없는"} ${v} 버튼${it.icon ? `(${it.icon} 아이콘 포함)` : ""}`;
+    case "iconButton": return `${it.icon ?? "빈"} 아이콘의 ${v} 아이콘 버튼`;
+    case "fab": return `${it.icon ?? "빈"} 아이콘의 ${v} FAB${it.size && it.size >= 96 ? "(대형)" : it.size && it.size <= 40 ? "(소형)" : ""}`;
+    case "extendedFab": return `${q(it.label)}${it.icon ? ` 및 ${it.icon} 아이콘` : ""} 확장 FAB(${v})`;
+    case "chip": return `${q(it.label)} 칩${it.checked ? "(선택됨)" : ""}${it.icon && !it.checked ? `(${it.icon} 아이콘 포함)` : ""}`;
+    case "topAppBar": return `제목이 ${q(it.label)}인 상단 앱 바${it.icon ? `, 왼쪽 ${it.icon}` : ""}${it.icon2 ? `, 오른쪽 ${it.icon2}` : ""}${it.icon || it.icon2 ? " 아이콘 버튼" : ""}`;
+    case "bottomNav": {
+      const tabs = (it.tabs ?? []).map((t) => `${q(t.label || "레이블 없음")}(${t.icon || "아이콘 없음"})`);
+      return `${tabs.length}개 항목의 내비게이션 바(${tabs.join(", ")}, 첫 항목 선택됨)`;
+    }
+    case "navRail": {
+      const tabs = (it.tabs ?? []).map((t) => `${q(t.label || "레이블 없음")}(${t.icon || "아이콘 없음"})`);
+      return `${tabs.length}개 항목의 내비게이션 레일(${tabs.join(", ")}, 첫 항목 선택됨)`;
+    }
+    case "searchBar": return `자리표시자가 ${q(it.label)}인 검색창${it.icon2 ? `(오른쪽 끝에 ${it.icon2} 아이콘)` : ""}`;
+    case "card": {
+      const style = it.variant === "elevated" ? "돌출" : it.variant === "outlined" ? "윤곽선" : "채움";
+      return `${style} 카드. 위쪽에 ${it.icon ? `${it.icon} 아이콘의 ` : ""}자리표시자 이미지, 제목 ${q(it.label)}${hasText(it.supporting) ? `, 본문 ${q(it.supporting!)}` : ""}`;
+    }
+    case "listItem": return `${q(it.label)}${hasText(it.supporting) ? `(보조 텍스트 ${q(it.supporting!)})` : ""}${it.icon ? `, 앞쪽 ${it.icon} 아이콘${it.iconFill === "none" ? "(배경 없음)" : it.iconFill ? `(배경 ${it.iconFill})` : ""}` : ""}${it.icon2 ? `, 뒤쪽 ${it.icon2}` : ""}${it.fill && it.fill !== "surfaceContainerLow" ? `, 배경 ${it.fill}` : ""}`;
+    case "dialog": return `제목 ${q(it.label)}${hasText(it.supporting) ? `, 본문 ${q(it.supporting!)}` : ""}${it.icon ? `, ${it.icon} 아이콘 포함` : ""} 대화상자(취소/확인 텍스트 버튼)`;
+    case "snackbar": return `${q(it.label)} 스낵바${hasText(it.supporting) ? `(${q(it.supporting!)} 동작 포함)` : ""}`;
+    case "textField": return `레이블이 ${q(it.label)}인 ${it.variant === "filled" ? "채움" : "윤곽선"} 텍스트 입력란${it.icon ? `(앞쪽 ${it.icon} 아이콘)` : ""}${hasText(it.supporting) ? `. 보조 텍스트는 ${q(it.supporting!)}` : ""}`;
+    case "switch": return `${q(it.label)} 스위치(초기 상태 ${it.checked ? "켜짐" : "꺼짐"}${it.noCheck ? ", 켜졌을 때 핸들에 체크 아이콘 없음" : ""})`;
+    case "checkbox": return `${q(it.label)} 체크박스(초기 상태 ${it.checked ? "선택됨" : "선택 안 됨"})`;
+    case "slider": return `슬라이더(초깃값 ${it.value ?? 40}%)`;
+    case "text": return `${it.bold ? "굵은 " : ""}텍스트 ${q(it.label)}(${it.size ?? 28}sp)`;
+    case "image": return `${it.size ?? 200}dp 정사각형 이미지${it.src ? "(지정한 이미지 표시)" : " 자리표시자"}`;
+    case "divider": return "구분선";
+    case "box": return `${it.size ?? PHONE_W}×${it.size2 ?? 220}dp ${it.checked ? "하단 시트(위쪽 드래그 핸들 포함)" : "상자"}(배경 ${it.fill ?? "surfaceContainerLow"}, 위쪽 모서리 ${it.radiusTop ?? 28}dp / 아래쪽 ${it.radiusBottom ?? 28}dp)`;
+    case "loadingIndicator": return `M3 Expressive 형태 변환 로딩 표시기${it.contained ? "(컨테이너 포함)" : ""}`;
+    case "linearProgress": return `${it.wavy ? "물결 모양 " : ""}선형 진행 표시기(${it.value === undefined ? "불확정" : `${it.value}%`})`;
+    case "circularProgress": return `${it.wavy ? "물결 모양 " : ""}원형 진행 표시기(${it.value === undefined ? "불확정" : `${it.value}%`})`;
+    case "splitButton": return `${q(it.label)}${it.icon ? `(${it.icon} 아이콘 포함)` : ""} ${v} 분할 버튼(오른쪽에 아래쪽 화살표가 있는 메뉴 영역)`;
+    case "fabMenu": {
+      const items = (it.tabs ?? []).map((t) => `${q(t.label || "레이블 없음")}(${t.icon || "아이콘 없음"})`);
+      return `${v} FAB에서 열리는 FAB 메뉴(열린 상태로 표시, 위쪽에 ${items.join(", ")} 항목 ${items.length}개를 세로 배치)`;
+    }
+    case "toolbar": {
+      const icons = (it.tabs ?? []).map((t) => t.icon || "빈 아이콘").join(", ");
+      return `${it.variant === "filled" ? "비브런트(primaryContainer)" : "표준"} 플로팅 도구 모음(${icons} 아이콘 버튼)`;
+    }
+    case "tabs": {
+      const labels = (it.tabs ?? []).map((t) => q(t.label || "레이블 없음"));
+      return `${labels.join(", ")}의 탭 ${labels.length}개(첫 탭 선택됨)`;
+    }
+    case "radio": return `${q(it.label)} 라디오 버튼(초기 상태 ${it.checked ? "선택됨" : "선택 안 됨"})`;
+    case "badge": return hasText(it.label) ? `${q(it.label)}을 표시하는 배지` : "작은 점 배지";
+    default: return noun;
+  }
+}
+
+const itemText = (it: Item, lang: Lang) => (lang === "ja" ? itemJa(it) : lang === "zh" ? itemZh(it) : lang === "ko" ? itemKo(it) : itemEn(it));
 
 /* ================= connected runs ================= */
 
@@ -314,6 +372,15 @@ function groupText(g: Group, lang: Lang): string {
       : g.items.map((it) => `${q(it.label || "无标签")}(${vt[it.variant]})`).join("");
     return `由${names}这 ${g.items.length} 个按钮横向相连组成的按钮组${same ? `（${vt[g.items[0].variant]}）` : ""}`;
   }
+  if (lang === "ko") {
+    if (kind === "listItem") return `${g.items.length}개 항목의 목록. 위에서부터 ${g.items.map(itemKo).join(", ")}`;
+    if (kind === "chip") return `${g.items.map((it) => q(it.label) + (it.checked ? "(선택됨)" : "")).join(", ")} 칩을 가로로 배치한 칩 그룹`;
+    if (kind === "iconButton") return `${g.items.map((it) => it.icon ?? "빈 아이콘").join(", ")} 아이콘 버튼을 연결한 버튼 그룹`;
+    const names = same
+      ? g.items.map((it) => q(it.label || "레이블 없음")).join(", ")
+      : g.items.map((it) => `${q(it.label || "레이블 없음")}(${vt[it.variant]})`).join(", ");
+    return `${names} 버튼 ${g.items.length}개를 가로로 연결한 버튼 그룹${same ? `(${vt[g.items[0].variant]})` : ""}`;
+  }
   if (kind === "listItem") return `a list of ${g.items.length} items, top to bottom: ${g.items.map(itemEn).join("; ")}`;
   if (kind === "chip") return `a chip group: ${g.items.map((it) => q(it.label) + (it.checked ? " (selected)" : "")).join(", ")}`;
   if (kind === "iconButton") return `a connected group of icon buttons: ${g.items.map((it) => it.icon ?? "empty").join(", ")}`;
@@ -328,9 +395,9 @@ function groupName(g: Group, lang: Lang): string {
   const it = g.items[0];
   const noun = KIND_TEXT[lang][it.kind]?.noun ?? it.kind;
   const q = quote(lang);
-  if (g.items.length > 1) return lang === "en" ? `the ${noun} group` : lang === "zh" ? `${noun}组` : `${noun}のグループ`;
-  if (it.kind === "box") return lang === "en" ? (it.checked ? "the bottom sheet" : "the box") : lang === "zh" ? (it.checked ? "底部面板" : "容器框") : it.checked ? "ボトムシート" : "ボックス";
-  if (hasText(it.label) && it.kind !== "text") return lang === "en" ? `the ${q(it.label)} ${noun}` : `${q(it.label)}${noun}`;
+  if (g.items.length > 1) return lang === "en" ? `the ${noun} group` : lang === "zh" ? `${noun}组` : lang === "ko" ? `${noun} 그룹` : `${noun}のグループ`;
+  if (it.kind === "box") return lang === "en" ? (it.checked ? "the bottom sheet" : "the box") : lang === "zh" ? (it.checked ? "底部面板" : "容器框") : lang === "ko" ? (it.checked ? "하단 시트" : "상자") : it.checked ? "ボトムシート" : "ボックス";
+  if (hasText(it.label) && it.kind !== "text") return lang === "en" ? `the ${q(it.label)} ${noun}` : `${q(it.label)}${lang === "ko" ? " " : ""}${noun}`;
   return lang === "en" ? `the ${noun}` : noun;
 }
 
@@ -339,14 +406,15 @@ function groupName(g: Group, lang: Lang): string {
 function actionText(a: Action, frames: Frame[], lang: Lang): string | null {
   const q = quote(lang);
   if (a.to === BACK_TARGET) {
-    return lang === "ja" ? "前の画面に戻る（入ったときの遷移を逆再生する）" : lang === "zh" ? "返回上一个屏幕（反向播放进入时的过渡动画）" : "goes back to the previous screen (playing the entry transition in reverse)";
+    return lang === "ja" ? "前の画面に戻る（入ったときの遷移を逆再生する）" : lang === "zh" ? "返回上一个屏幕（反向播放进入时的过渡动画）" : lang === "ko" ? "이전 화면으로 돌아간다(진입 전환을 반대로 재생)" : "goes back to the previous screen (playing the entry transition in reverse)";
   }
   const target = frames.find((f) => f.id === a.to);
   if (!target) return null;
   const tr = TRANSITION_TEXT[lang][a.transition];
-  const name = q(target.name || (lang === "en" ? "screen" : lang === "zh" ? "屏幕" : "画面"));
+  const name = q(target.name || (lang === "en" ? "screen" : lang === "zh" ? "屏幕" : lang === "ko" ? "화면" : "画面"));
   if (lang === "ja") return `${name}画面へ${a.transition !== "none" ? `${tr}で` : ""}遷移する`;
   if (lang === "zh") return `${a.transition !== "none" ? `以${tr}的方式` : ""}跳转到${name}屏幕`;
+  if (lang === "ko") return `${name} 화면으로${a.transition !== "none" ? ` ${tr} 전환하여` : ""} 이동한다`;
   return `opens the ${name} screen${a.transition !== "none" ? ` with ${tr}` : ""}`;
 }
 
@@ -356,11 +424,12 @@ function slotName(it: Item, slot: string, lang: Lang): string {
     const tab = it.tabs?.[i];
     const q = quote(lang);
     const label = tab?.label ? q(tab.label) : `#${i + 1}`;
-    return lang === "ja" ? `${label}の項目` : lang === "zh" ? `${label}项` : `the ${label} destination`;
+    return lang === "ja" ? `${label}の項目` : lang === "zh" ? `${label}项` : lang === "ko" ? `${label} 항목` : `the ${label} destination`;
   }
   const icon = slot === "icon2" ? it.icon2 : it.icon;
   if (lang === "ja") return `${slot === "icon2" ? "右" : "左"}の ${icon ?? ""} アイコンボタン`;
   if (lang === "zh") return `${slot === "icon2" ? "右侧" : "左侧"}的 ${icon ?? ""} 图标按钮`;
+  if (lang === "ko") return `${slot === "icon2" ? "오른쪽" : "왼쪽"} ${icon ?? ""} 아이콘 버튼`;
   return `the ${icon ?? ""} icon button on the ${slot === "icon2" ? "right" : "left"}`;
 }
 
@@ -369,11 +438,11 @@ function notes(g: Group, frames: Frame[], lang: Lang): string[] {
   const q = quote(lang);
   for (const it of g.items) {
     const noun = KIND_TEXT[lang][it.kind]?.noun ?? it.kind;
-    const name = hasText(it.label) && it.kind !== "text" ? (lang === "en" ? `The ${q(it.label)} ${noun}` : `${q(it.label)}${noun}`) : lang === "en" ? `The ${noun}` : hasText(it.label) ? (lang === "ja" ? `テキスト${q(it.label)}` : `文本${q(it.label)}`) : noun;
+    const name = hasText(it.label) && it.kind !== "text" ? (lang === "en" ? `The ${q(it.label)} ${noun}` : `${q(it.label)}${lang === "ko" ? " " : ""}${noun}`) : lang === "en" ? `The ${noun}` : hasText(it.label) ? (lang === "ja" ? `テキスト${q(it.label)}` : lang === "zh" ? `文本${q(it.label)}` : `텍스트 ${q(it.label)}`) : noun;
     const parts: string[] = [];
     if (it.action) {
       const a = actionText(it.action, frames, lang);
-      if (a) parts.push(lang === "ja" ? `タップすると${a}` : lang === "zh" ? `点击后${a}` : `${a} when tapped`);
+      if (a) parts.push(lang === "ja" ? `タップすると${a}` : lang === "zh" ? `点击后${a}` : lang === "ko" ? `탭하면 ${a}` : `${a} when tapped`);
     }
     for (const [slot, action] of Object.entries(it.actions ?? {})) {
       if (!action) continue;
@@ -381,7 +450,7 @@ function notes(g: Group, frames: Frame[], lang: Lang): string[] {
       if (!a) continue;
       const s = slotName(it, slot, lang);
       if (lang === "en") out.push(`Tapping ${s} of ${name.replace(/^The /, "the ")} ${a}.`);
-      else parts.push(lang === "ja" ? `${s}をタップすると${a}` : `点击${s}后${a}`);
+      else parts.push(lang === "ja" ? `${s}をタップすると${a}` : lang === "zh" ? `点击${s}后${a}` : `${s}을 탭하면 ${a}`);
     }
     if (it.toggle) {
       const vt = VARIANT_TEXT[lang];
@@ -401,6 +470,12 @@ function notes(g: Group, frames: Frame[], lang: Lang): string[] {
         else if (icon === null) changes.push("图标消失");
         if (variant) changes.push(`样式变为${vt[variant]}`);
         parts.push(`做成每次点击都切换开/关状态的切换按钮${changes.length ? `（开启时${changes.join("、")}）` : ""}`);
+      } else if (lang === "ko") {
+        if (label !== undefined) changes.push(`레이블이 ${qe(label)}로 바뀐다`);
+        if (icon) changes.push(`아이콘이 ${icon}(으)로 바뀐다`);
+        else if (icon === null) changes.push("아이콘이 사라진다");
+        if (variant) changes.push(`스타일이 ${vt[variant]}(으)로 바뀐다`);
+        parts.push(`탭할 때마다 켜짐/꺼짐이 전환되는 토글 버튼으로 만든다${changes.length ? `(켜졌을 때 ${changes.join(", ")})` : ""}`);
       } else {
         if (label !== undefined) changes.push(`the label becomes ${qe(label)}`);
         if (icon) changes.push(`the icon becomes ${icon}`);
@@ -413,6 +488,7 @@ function notes(g: Group, frames: Frame[], lang: Lang): string[] {
     if (!parts.length) continue;
     if (lang === "ja") out.push(`${name}は、${parts.join("。また、")}。`);
     else if (lang === "zh") out.push(`${name}：${parts.join("；")}。`);
+    else if (lang === "ko") out.push(`${name}: ${parts.join(". 또한 ")}.`);
     else out.push(`${name} ${parts.join(". It also ")}.`);
   }
   return out;
@@ -421,7 +497,7 @@ function notes(g: Group, frames: Frame[], lang: Lang): string[] {
 function swipeNotes(f: Frame, frames: Frame[], lang: Lang): string[] {
   const out: string[] = [];
   const q = quote(lang);
-  const screen = lang === "en" ? "screen" : lang === "zh" ? "屏幕" : "画面";
+  const screen = lang === "en" ? "screen" : lang === "zh" ? "屏幕" : lang === "ko" ? "화면" : "画面";
   for (const d of SWIPE_DIRS) {
     const to = f.swipe?.[d.key];
     if (!to) continue;
@@ -431,6 +507,7 @@ function swipeNotes(f: Frame, frames: Frame[], lang: Lang): string[] {
     const name = q(f.name || screen);
     if (lang === "ja") out.push(`${name}画面は、${sw}すると指の動きに追従して${a}。`);
     else if (lang === "zh") out.push(`${name}屏幕：${sw}时跟随手指移动并${a}。`);
+    else if (lang === "ko") out.push(`${name} 화면은 ${sw}하면 손가락을 따라 움직이며 ${a}.`);
     else out.push(`The ${name} screen ${a} when ${sw}; the screen follows the finger while dragging.`);
   }
   return out;
@@ -507,6 +584,12 @@ function zone(bb: Rect, within: Rect, lang: Lang, phone: boolean): string {
     const hh = horiz < 0 ? "" : ["靠左", "", "靠右"][horiz];
     return `${v}${hh}`;
   }
+  if (lang === "ko") {
+    const v = ["위쪽", "가운데", "아래쪽"][vert];
+    if (horiz === 1) return `${v} 중앙에`;
+    const hh = horiz < 0 ? "" : [" 왼쪽 정렬로", "", " 오른쪽 정렬로"][horiz];
+    return `${v}${hh}`;
+  }
   const v = ["Near the top", "In the middle", "Near the bottom"][vert];
   const hh = horiz < 0 ? "" : [", aligned left", ", centered", ", aligned right"][horiz];
   return `${v}${hh}`;
@@ -516,7 +599,7 @@ function zone(bb: Rect, within: Rect, lang: Lang, phone: boolean): string {
 function rowText(row: LNode[], where: string, lang: Lang, within: Rect): string {
   if (row.length === 1) {
     const d = groupText(row[0].g, lang);
-    return lang === "ja" ? `${where}${d}を置きます。` : lang === "zh" ? `${where}放置${d}。` : `${where}: ${d}.`;
+    return lang === "ja" ? `${where}${d}を置きます。` : lang === "zh" ? `${where}放置${d}。` : lang === "ko" ? `${where} ${d}을(를) 배치합니다.` : `${where}: ${d}.`;
   }
   const last = row[row.length - 1];
   const fillsRight = last.bb.r >= within.r - 24;
@@ -528,6 +611,10 @@ function rowText(row: LNode[], where: string, lang: Lang, within: Rect): string 
   if (lang === "zh") {
     const stretch = fillsRight ? `，最后的${groupName(last.g, "zh")}向右拉伸占满剩余宽度` : "";
     return `${where}，从左到右横向排成一行：${descs.join("、")}（放在同一行并垂直居中，不要竖着堆叠或换行${stretch}）。`;
+  }
+  if (lang === "ko") {
+    const stretch = fillsRight ? `, 마지막 ${groupName(last.g, "ko")}은(는) 오른쪽 끝까지 남은 너비를 채웁니다` : "";
+    return `${where}, 왼쪽부터 한 행에 ${descs.join(", ")}을(를) 배치합니다(같은 줄에 세로 중앙 정렬하고 쌓거나 줄 바꿈하지 않음${stretch}).`;
   }
   const stretch = fillsRight ? `; ${groupName(last.g, "en")} stretches to fill the remaining width to the right edge` : "";
   return `${where}, in one row from left to right: ${descs.join(", ")} (keep them on the same line, vertically centered; never stack or wrap them${stretch}).`;
@@ -552,7 +639,7 @@ function describeNodes(lines: string[], nodes: LNode[], within: Rect | null, wid
     };
     let where: string;
     if (within) where = zone(rowRect, box, lang, phone);
-    else where = lang === "ja" ? (i === 0 ? "まず" : "その下に") : lang === "zh" ? (i === 0 ? "首先" : "其下方") : i === 0 ? "First" : "Below that";
+    else where = lang === "ja" ? (i === 0 ? "まず" : "その下に") : lang === "zh" ? (i === 0 ? "首先" : "其下方") : lang === "ko" ? (i === 0 ? "먼저" : "그 아래에") : i === 0 ? "First" : "Below that";
     /* a part that partly covers an earlier sibling is drawn on top of it */
     const overlaps: string[] = [];
     if (row.length === 1) {
@@ -564,29 +651,29 @@ function describeNodes(lines: string[], nodes: LNode[], within: Rect | null, wid
     }
     let line = rowText(row, where, lang, box);
     if (overlaps.length) {
-      const o = overlaps.join(lang === "en" ? " and " : "、");
-      line = lang === "ja" ? `${line.replace(/。$/, "")}（${o}の上に一部重ねて前面に描画）。` : lang === "zh" ? `${line.replace(/。$/, "")}（部分覆盖在${o}之上，绘制在前面）。` : `${line.replace(/\.$/, "")} (partly overlapping ${o}, drawn on top).`;
+      const o = overlaps.join(lang === "en" ? " and " : lang === "ko" ? ", " : "、");
+      line = lang === "ja" ? `${line.replace(/。$/, "")}（${o}の上に一部重ねて前面に描画）。` : lang === "zh" ? `${line.replace(/。$/, "")}（部分覆盖在${o}之上，绘制在前面）。` : lang === "ko" ? `${line.replace(/\.$/, "")}(${o} 위에 일부 겹쳐 앞쪽에 그림).` : `${line.replace(/\.$/, "")} (partly overlapping ${o}, drawn on top).`;
     }
     lines.push(`${pad}- ${line}`);
     for (const n of row) {
       if (!n.children.length) continue;
       const name = groupName(n.g, lang);
       lines.push(
-        `${pad}  - ${lang === "ja" ? `${name}の中には次を重ねて配置します（ボックス側を背景にし、以下はその前面に載せる。位置はボックス内での相対位置）:` : lang === "zh" ? `${name}内部叠放以下内容（以容器为背景，下列组件绘制在其前面，位置为容器内的相对位置）：` : `Inside ${name}, layered on top of it (the container is the background; positions are relative to it):`}`,
+        `${pad}  - ${lang === "ja" ? `${name}の中には次を重ねて配置します（ボックス側を背景にし、以下はその前面に載せる。位置はボックス内での相対位置）:` : lang === "zh" ? `${name}内部叠放以下内容（以容器为背景，下列组件绘制在其前面，位置为容器内的相对位置）：` : lang === "ko" ? `${name} 안에 다음 항목을 겹쳐 배치합니다(컨테이너를 배경으로 하고 다음 부품은 그 앞에 배치하며, 위치는 컨테이너 내부 기준):` : `Inside ${name}, layered on top of it (the container is the background; positions are relative to it):`}`,
       );
       describeNodes(lines, n.children, n.bb, widths, lang, depth + 2, false);
     }
   });
 }
 
-const RAIL_LEAD: Record<Lang, string> = { ja: "左端に", en: "Along the left edge: ", zh: "左缘：" };
+const RAIL_LEAD: Record<Lang, string> = { ja: "左端に", en: "Along the left edge: ", zh: "左缘：", ko: "왼쪽 가장자리에 " };
 
 function describeScreen(lines: string[], groups: Group[], frameRect: Rect | null, widths: Record<string, number>, lang: Lang) {
   if (!groups.length) return;
   /* a navigation rail runs the full height, so it is written first, on its own; the
    * rest of the screen is then read beside it in rows as usual */
   const rails = groups.filter((g) => g.items.length === 1 && g.items[0].kind === "navRail");
-  for (const g of rails) lines.push(`- ${RAIL_LEAD[lang]}${itemText(g.items[0], lang)}${lang === "en" ? "." : "。"}`);
+  for (const g of rails) lines.push(`- ${RAIL_LEAD[lang]}${itemText(g.items[0], lang)}${lang === "ja" || lang === "zh" ? "。" : "."}`);
   const rest = rails.length ? groups.filter((g) => !rails.includes(g)) : groups;
   if (!rest.length) return;
   const roots = layoutTree(rest, widths);
@@ -774,6 +861,39 @@ const STYLE_NOTES: Record<Lang, Partial<Record<Kind | "boxSheet", string>>> = {
     radio: "单选按钮：20dp 圆形。选中时为 primary 的圆环加中心圆点，未选中为 onSurfaceVariant 圆环。同一组内只能选一个。标签在右侧，用 bodyLarge。",
     badge: "徽标：无文字时为 6dp 圆点，有文字时为高 16dp 的胶囊。背景为 error，文字为 onError 的 labelSmall。叠放在图标或项目的右上角。",
   },
+  ko: {
+    button: "버튼: 높이 56dp의 중간 크기, 완전 둥근 알약 모양. 채움은 primary, 토널은 secondaryContainer, 윤곽선은 1dp outline 테두리를 사용한다. 연결 버튼 그룹은 간격 3dp, 맞닿는 안쪽 모서리 8dp, 바깥쪽 모서리는 둥글게 유지한다.",
+    navRail: "내비게이션 레일: 너비 80dp, 배경 surfaceContainer, 왼쪽 가장자리의 전체 높이를 채운다. 항목은 위에서부터 세로로 배치한다. 선택 항목은 secondaryContainer 알약 표시기(56×32dp), 채운 아이콘과 아래쪽 labelMedium 레이블로 표시한다. 콘텐츠는 레일 오른쪽에 배치한다.",
+    iconButton: "아이콘 버튼: 48dp 원형. 지정된 채움, 토널, 윤곽선, 표준 스타일을 사용하며 연결된 아이콘 버튼은 Connected button group으로 구현한다.",
+    fab: "FAB: 기본 56dp/모서리 16dp, 대형 96dp/28dp, 소형 40dp/12dp. 토널은 primaryContainer, 채움은 primary를 사용하고 화면 가장자리에서 16dp 띄워 Level 3 그림자를 적용한다.",
+    extendedFab: "확장 FAB: 높이 56dp, 모서리 16dp, 왼쪽에 아이콘, 오른쪽에 레이블을 둔다.",
+    chip: "칩: 높이 32dp, 모서리 8dp. 선택 상태는 secondaryContainer로 채우고 앞쪽에 체크 아이콘을 표시한다. 칩 그룹은 간격 8dp로 가로 배치하고 넘치면 가로 스크롤한다.",
+    topAppBar: "상단 앱 바: 높이 64dp, 배경 surface. 상태 표시줄 뒤까지 배경을 늘리고 시스템 인셋만큼 위쪽 여백을 둔다. 제목은 titleLarge, 양쪽 아이콘 버튼은 48dp를 사용한다.",
+    bottomNav: "내비게이션 바: 높이 80dp, 배경 surfaceContainer. 제스처 내비게이션 영역까지 배경을 늘리고 시스템 인셋만큼 아래쪽 여백을 둔다. 선택 항목은 64×32dp secondaryContainer 알약 표시기, 채운 아이콘, labelMedium 레이블로 표시한다.",
+    searchBar: "검색창: 높이 56dp, 완전 둥근 모서리, 배경 surfaceContainerHigh. 앞쪽 검색 아이콘과 지정된 뒤쪽 아이콘을 둔다.",
+    card: "카드: 모서리 20dp, 위쪽 이미지 영역. 채움은 surfaceContainerHighest, 돌출은 surfaceContainerLow와 Level 1 그림자, 윤곽선은 1dp outlineVariant 테두리를 사용한다. 제목 titleMedium, 본문 bodyMedium, 안쪽 여백 16dp.",
+    listItem: "목록 항목: 높이 72dp, 앞쪽 아이콘 24dp(별도 지정이 없으면 40dp primaryContainer 원 위), 주 텍스트 bodyLarge, 보조 텍스트 bodyMedium/onSurfaceVariant. 연결 목록은 간격 3dp, 바깥 모서리 28dp, 안쪽 모서리 8dp.",
+    dialog: "대화상자: 너비 312dp, 모서리 28dp, 배경 surfaceContainerHigh. 제목 headlineSmall, 본문 bodyMedium, 텍스트 버튼은 아래쪽 오른쪽 정렬.",
+    snackbar: "스낵바: 높이 48dp, 모서리 8dp, inverseSurface 배경과 inverseOnSurface 텍스트. 동작은 inversePrimary 텍스트 버튼으로 하고 아래쪽에서 16dp 띄워 몇 초 뒤 닫는다.",
+    textField: "텍스트 입력란: 높이 56dp. 윤곽선형은 모서리 16dp와 outline 테두리, 채움형은 surfaceContainerHighest 배경과 밑줄을 사용한다. 포커스 시 레이블을 올리고 테두리를 2dp primary로 바꾼다.",
+    switch: "스위치: M3 표준 크기(트랙 52×32dp). 켜짐은 primary, 꺼짐은 surfaceContainerHighest와 outline 테두리. 레이블은 왼쪽, 스위치는 오른쪽에 둔다.",
+    checkbox: "체크박스: 18dp 사각형, 모서리 2dp, 선택 시 primary. 레이블은 오른쪽에 bodyLarge로 표시한다.",
+    slider: "슬라이더: M3 Expressive의 두꺼운 16dp 트랙과 4×44dp 세로 핸들. 핸들 왼쪽은 primary, 오른쪽은 secondaryContainer이며 드래그로 값을 바꾼다.",
+    text: "텍스트: 지정된 sp 크기. 제목은 onSurface, 설명은 onSurfaceVariant, 줄 높이는 글자 크기의 1.3~1.5배. 탭 반응은 넣지 않는다.",
+    image: "이미지: 모서리 20dp. 이미지가 없으면 surfaceContainerHighest 자리표시자를 사용하고 비율을 유지해 가운데에서 자른다.",
+    divider: "구분선: 1dp outlineVariant, 좌우 여백 16dp.",
+    box: "상자: 지정된 배경 토큰과 모서리를 가진 단순 컨테이너. 겹쳐 놓은 부품의 배경으로 사용하며 자체 동작은 넣지 않는다.",
+    boxSheet: "상자/하단 시트: 지정된 배경과 모서리를 가진 컨테이너. 드래그 핸들이 명시된 것만 아래에서 올라오는 ModalBottomSheet로 만들고 나머지는 단순 배경 컨테이너로 둔다.",
+    loadingIndicator: "로딩: 다각형이 회전하며 형태가 바뀌는 M3 Expressive LoadingIndicator를 사용한다. 컨테이너형은 secondaryContainer 원 안에 둔다.",
+    linearProgress: "선형 진행 표시기: M3 Expressive의 두꺼운 바. 지정된 경우 물결 스타일을 사용하며 트랙은 secondaryContainer, 진행은 primary로 표시한다.",
+    circularProgress: "원형 진행 표시기: M3 Expressive의 두꺼운 스트로크. 지정된 경우 물결 스타일을 사용한다.",
+    splitButton: "분할 버튼: M3 Expressive SplitButton. 왼쪽은 주 동작, 오른쪽 화살표 영역은 메뉴를 연다. 두 영역 간격 2dp, 바깥 모서리는 완전 둥글게, 안쪽은 8dp로 한다.",
+    fabMenu: "FAB 메뉴: M3 Expressive FloatingActionButtonMenu. 닫혔을 때는 일반 FAB이고 탭하면 항목이 위로 차례로 나타나며 아이콘은 close로 바뀐다. 각 항목은 높이 56dp, 완전 둥근 모서리, 아이콘과 레이블을 포함한다.",
+    toolbar: "플로팅 도구 모음: M3 Expressive HorizontalFloatingToolbar. 높이 64dp, 완전 둥근 모서리로 화면 아래쪽에서 16dp 띄운다. 표준은 surfaceContainer, 비브런트는 primaryContainer, 내부 아이콘 버튼은 48dp.",
+    tabs: "탭: M3 기본 탭. 높이 48dp, 레이블 titleSmall. 선택 탭은 primary 텍스트와 레이블 너비의 3dp 표시기를 사용하고 아래에 outlineVariant 구분선을 둔다.",
+    radio: "라디오 버튼: 20dp 원형. 선택 시 primary 테두리와 가운데 점, 미선택 시 onSurfaceVariant 테두리. 그룹에서 하나만 선택되며 레이블은 오른쪽 bodyLarge.",
+    badge: "배지: 텍스트가 없으면 6dp 점, 있으면 높이 16dp 알약 모양. 배경 error, 텍스트 onError/labelSmall로 아이콘이나 항목 오른쪽 위에 겹쳐 둔다.",
+  },
 };
 
 /* ---------- theme: shape, type, motion ---------- */
@@ -782,6 +902,7 @@ const FONT_NOTE: Record<Lang, (name: string) => string> = {
   ja: (n) => `書体は ${n} を使う。`,
   en: (n) => `Use ${n} as the typeface.`,
   zh: (n) => `字体使用 ${n}。`,
+  ko: (n) => `글꼴은 ${n}을(를) 사용한다.`,
 };
 
 const THEME_NOTES: Record<Lang, { shape: Record<Theme["shape"], string>; emphasized: string; plainType: string; motion: Record<Theme["motion"], string> }> = {
@@ -824,13 +945,26 @@ const THEME_NOTES: Record<Lang, { shape: Record<Theme["shape"], string>; emphasi
       expressive: "动效使用 MotionScheme.expressive()：屏幕过渡和状态变化带轻微回弹的弹簧效果。",
     },
   },
+  ko: {
+    shape: {
+      square: "모서리는 절제한다. 전체 M3 모양 배율을 줄이고(버튼과 칩 8~12dp, 카드와 이미지 8dp, 대화상자 약 12dp) 알약 모양은 사용하지 않는다.",
+      rounded: "M3 Expressive 기본 모서리를 사용한다(버튼은 알약 모양, 카드 20dp, 대화상자 28dp).",
+      full: "모서리를 최대한 둥글게 한다. 버튼, 칩, 입력란은 알약 모양, 카드와 이미지 32dp, 대화상자와 시트는 약 40dp로 한다.",
+    },
+    emphasized: "제목, 버튼 레이블, 탭은 더 굵은 headlineMediumEmphasized 등 M3 Expressive 강조 글꼴 스타일을 사용한다.",
+    plainType: "M3 표준 글자 굵기를 사용한다.",
+    motion: {
+      standard: "모션은 MotionScheme.standard()를 사용한다. 화면 전환과 상태 변화는 튀지 않고 부드럽게 처리한다.",
+      expressive: "모션은 MotionScheme.expressive()를 사용한다. 화면 전환과 상태 변화에 가볍게 튀는 스프링 효과를 적용한다.",
+    },
+  },
 };
 
 function themeLines(th: Theme, lang: Lang): string[] {
   const n = THEME_NOTES[lang];
   const font = FONTS.find((f) => f.key === th.font);
-  const fontName = font?.key === "system" ? (lang === "ja" ? "端末のシステムフォント" : lang === "zh" ? "设备的系统字体" : "the device's system font") : (font?.label ?? "Roboto");
-  const sp = lang === "en" ? " " : "";
+  const fontName = font?.key === "system" ? (lang === "ja" ? "端末のシステムフォント" : lang === "zh" ? "设备的系统字体" : lang === "ko" ? "기기의 시스템 글꼴" : "the device's system font") : (font?.label ?? "Roboto");
+  const sp = lang === "en" || lang === "ko" ? " " : "";
   return [`- ${n.shape[th.shape]}`, `- ${FONT_NOTE[lang](fontName)}${sp}${th.emphasized ? n.emphasized : n.plainType}`, `- ${n.motion[th.motion]}`];
 }
 
@@ -878,10 +1012,28 @@ const GENERAL: Record<Lang, (string | ((pl: Platform) => string))[]> = {
     "图标使用 Material Symbols Rounded。",
     (pl: Platform) => `不需要在${pl === "web" ? "浏览器" : "模拟器或真机"}上验证。实现完成后${pl === "web" ? "运行 production build 并提供其输出" : "生成已签名的 release APK "}作为交付物。`,
   ],
+  ko: [
+    "화면의 목적에서 앱의 종류를 판단하고, 스케치에 없더라도 그 종류의 앱에 일반적으로 필요한 기능(만들기, 목록, 상세, 편집, 삭제, 검색, 설정 등)을 구현한다.",
+    (pl: Platform) => `데이터를 실제 데이터로 취급한다. 사용자가 만든 데이터는 ${pl === "web" ? "브라우저(IndexedDB 등)에 저장해 새로고침" : "기기(Room, DataStore 등)에 저장해 재시작"} 후에도 유지한다. 더미나 샘플 데이터는 넣지 않고 데이터가 없으면 빈 상태를 표시한다. 입력을 검증하고 실패와 삭제는 적절히 확인하거나 알린다.`,
+    "스케치에 없는 동작은 화면 목적과 부품 레이블을 바탕으로 보완한다. 동작이 지정되지 않은 버튼이나 항목도 레이블에 맞는 동작(저장, 보내기, 상세 화면 열기 등)을 수행해야 한다.",
+    "레이아웃은 의도한 순서, 그룹, 상대 위치를 유지하되 크기와 간격은 내용에 맞게 조정할 수 있다. 실제 기기에서 깨진다면 스케치 일치보다 정상 동작을 우선한다.",
+    (pl: Platform) => `${pl === "web" ? "Material Web" : "최신 Expressive API를 포함한 Jetpack Compose material3"}의 표준 컴포넌트를 사용하고 라이브러리에 있는 부품을 직접 그리지 않는다.`,
+    "색상은 하드코딩하지 말고 위 색상 구성의 역할 이름(primary, surfaceContainer 등)으로 참조한다.",
+    "화면 가장자리는 16dp, 부품 사이는 8~16dp를 기본으로 하고 M3 글꼴 스타일(titleLarge, bodyMedium 등)을 사용한다.",
+    "'한 행에 배치'한 부품은 하나의 Row(가로 컨테이너)에서 같은 줄에 두고 세로로 쌓거나 줄 바꿈하지 않는다. 행 높이는 가장 높은 부품에 맞추고 나머지는 세로 중앙 정렬한다.",
+    "'내부에 겹쳐 배치'한 부품은 해당 컨테이너(상자 또는 카드)를 배경으로 하는 Box 위에 그린다. 이 겹침은 의도된 것이므로 분리하거나 순서를 바꾸지 않으며 나중에 설명된 항목을 앞에 그린다.",
+    "탭 가능한 부품에는 리플과 약한 축소 피드백을 준다. '뒤로'는 진입 전환을 반대로 재생하고 시스템 뒤로 제스처나 버튼도 같은 동작을 수행한다.",
+    "아이콘은 Material Symbols Rounded를 사용한다.",
+    (pl: Platform) => `${pl === "web" ? "브라우저" : "에뮬레이터나 실제 기기"} 동작 검증은 필요 없다. 구현 후 ${pl === "web" ? "production build를 실행하고 그 출력" : "서명된 release APK"}을 결과물로 제공한다.`,
+  ],
 };
 
 /** notes that differ on the web, where a browser has no status bar or gesture area to inset for */
 const STYLE_NOTES_WEB: Record<Lang, Partial<Record<Kind, string>>> = {
+  ko: {
+    topAppBar: "상단 앱 바: 높이 64dp, 배경 surface. 제목은 titleLarge, 양쪽 아이콘 버튼은 48dp를 사용한다. 스크롤 시 surfaceContainer로 색상이 바뀌는 표준 동작을 사용한다.",
+    bottomNav: "내비게이션 바: 높이 80dp, 배경 surfaceContainer. 선택 항목은 secondaryContainer 알약 표시기(64×32dp), 채운 아이콘과 labelMedium 레이블로 표시한다.",
+  },
   ja: {
     topAppBar: "トップアプリバー: 高さ 64dp、背景は surface。タイトルは titleLarge、左右のアイコンボタンは 48dp。スクロール時に surfaceContainer へ色が変わる標準の挙動でよい。",
     bottomNav: "ナビゲーションバー: 高さ 80dp、背景は surfaceContainer。選択中の項目は secondaryContainer のピル型インジケータ（幅 64dp・高さ 32dp）で示し、アイコンは塗りつぶし、ラベルは labelMedium。",
@@ -909,7 +1061,7 @@ const viewportOf = (frames: Frame[], phone: boolean): Viewport => {
 const sizeLabel = (f: Frame, vp: Viewport, lang: Lang): string | undefined => {
   if (vp !== "mixed") return undefined;
   const { w, h } = frameSizeOf(f);
-  const kind = isPhoneFrame(f) ? { ja: "スマホ", en: "phone", zh: "手机" } : { ja: "デスクトップ", en: "desktop", zh: "桌面" };
+  const kind = isPhoneFrame(f) ? { ja: "スマホ", en: "phone", zh: "手机", ko: "휴대전화" } : { ja: "デスクトップ", en: "desktop", zh: "桌面", ko: "데스크톱" };
   return `${kind[lang]} ${w}×${h}`;
 };
 
@@ -1040,6 +1192,33 @@ const PH = {
     styleIntro: "以下是所用组件的参考。数值均为 M3 Expressive 的标准值，能用标准组件实现的就交给标准组件，并可根据内容适当调整。",
     hGeneral: "## 整体原则",
   },
+  ko: {
+    screen: "화면",
+    intro: (title: string, brief: string) => `Material 3 Expressive 디자인으로 구현해 주세요: ${title}.${brief ? ` ${trimEnd(brief)}.` : ""}`,
+    titleOnly: (name: string) => `${name} 화면`,
+    titleAll: (n: number) => (n > 1 ? "이 앱" : "이 화면"),
+    target: (vp: Viewport, pl: Platform, dark: boolean, both: boolean) => `${vp === "phone" ? "세로형 휴대전화 화면(412×892dp)을 대상으로 하며" : vp === "desktop" ? `${pl === "web" ? "데스크톱 브라우저" : "가로형 태블릿"} 화면(1280×800 기준)을 대상으로 하며` : vp === "mixed" ? `세로형 휴대전화(412×892)와 ${pl === "web" ? "데스크톱 브라우저" : "가로형 태블릿"}(1280×800)을 모두 지원하며, 이름이 같은 화면은 서로 다른 너비의 동일한 화면이므로 반응형으로 구현하고` : "레이아웃은 자유 배치이며"}, ${both ? "라이트 모드와 다크 모드를 모두 지원하고 기기의 시스템 설정을 따른다" : `${dark ? "다크" : "라이트"} 모드만 지원한다`}.`,
+    platform: (pl: Platform) => (pl === "web" ? "브라우저에서 실행되는 웹 앱으로 구현한다." : "Android 네이티브 앱으로 구현한다."),
+    schemeHead: (dark: boolean) => (dark ? "다크 색상 구성:" : "라이트 색상 구성:"),
+    sketch: "아래 화면 구성은 의도를 전달하는 대략적인 스케치이며 완성 사양이 아니다. 정적인 그림처럼 복제하지 말고 이 종류의 제품에 일반적으로 필요한 기능을 갖춘 실제 사용 가능한 앱으로 완성한다.",
+    hColor: "## 색상",
+    dynamic: (pl: Platform) => pl === "web" ? "동적 색상을 사용한다. 브라우저나 운영체제에서 사용자의 강조 색상을 제공하면 이를 기준으로 Material 3 색상 구성을 생성하고, 사용할 수 없으면 아래 색상으로 대체한다." : "동적 색상을 사용한다. Android 12 이상에서는 사용자 배경화면에서 생성된 색상 구성(dynamicLightColorScheme / dynamicDarkColorScheme)을 적용하고 사용할 수 없는 기기에서는 아래 색상을 대체 값으로 사용한다.",
+    colorIntro: (label: string, fallback: boolean, th: Theme) => {
+      const scheme = `Material 3 ${th.bothModes ? "라이트 및 다크" : th.dark ? "다크" : "라이트"} 색상 구성${th.contrast === "high" ? "(고대비)" : th.contrast === "medium" ? "(중간 대비)" : ""}`;
+      return `${fallback ? "대체 테마" : "테마"}는 ${label} 계열이다. ${scheme}에 다음 색상을 설정하고 모든 UI 색상을 해당 역할로 참조한다.`;
+    },
+    hTheme: "## 모양, 글꼴 및 모션",
+    hLayout: "## 화면 구성",
+    empty: "화면에 아직 부품이 없습니다.",
+    screens: (names: string[]) => `화면은 ${names.length}개이며 ${names.join(", ")}입니다.`,
+    screenHead: (name: string, bg: string | undefined, has: boolean, size?: string) => `${name} 화면${size || bg ? `(${[size, bg ? `배경 ${bg}` : ""].filter(Boolean).join(", ")})` : ""}. ${has ? "위에서부터 다음과 같습니다. 겹친 부품은 별도로 표시합니다." : "아직 비어 있습니다."}`,
+    loose: "화면 밖에 놓인 부품(공통 부품 또는 참고):",
+    freeform: "화면을 위에서부터 설명합니다.",
+    hBehavior: "## 동작 및 화면 전환",
+    hStyle: "## 부품별 스타일",
+    styleIntro: "사용된 부품별 지침입니다. 수치는 M3 Expressive 기본값이며 표준 컴포넌트가 제공하는 동작은 그대로 사용하고 내용에 맞게 조정할 수 있습니다.",
+    hGeneral: "## 전체 지침",
+  },
 };
 
 export function buildPrompt(doc: Doc, widths: Record<string, number>, onlyFrameId?: string, lang: Lang = getLang()): string {
@@ -1113,7 +1292,7 @@ export function buildPrompt(doc: Doc, widths: Record<string, number>, onlyFrameI
     frames.forEach((f, i) => {
       const gs = byFrame.get(f.id) ?? [];
       if (i > 0 || frames.length > 1) lines.push("");
-      if (hasText(f.note)) lines.push(lang === "en" ? `${trimEnd(f.note!)}.` : `${trimEnd(f.note!)}。`);
+      if (hasText(f.note)) lines.push(lang === "ja" || lang === "zh" ? `${trimEnd(f.note!)}。` : `${trimEnd(f.note!)}.`);
       lines.push(ph.screenHead(q(f.name || ph.screen), f.bg && f.bg !== "surface" ? f.bg : undefined, gs.length > 0, sizeLabel(f, viewport, lang)));
       describeScreen(lines, gs, frameRect(f), widths, lang);
     });

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -471,10 +471,10 @@ function notes(g: Group, frames: Frame[], lang: Lang): string[] {
         if (variant) changes.push(`样式变为${vt[variant]}`);
         parts.push(`做成每次点击都切换开/关状态的切换按钮${changes.length ? `（开启时${changes.join("、")}）` : ""}`);
       } else if (lang === "ko") {
-        if (label !== undefined) changes.push(`레이블이 ${qe(label)}로 바뀐다`);
-        if (icon) changes.push(`아이콘이 ${icon}(으)로 바뀐다`);
+        if (label !== undefined) changes.push(`변경할 레이블: ${qe(label)}`);
+        if (icon) changes.push(`변경할 아이콘: ${icon}`);
         else if (icon === null) changes.push("아이콘이 사라진다");
-        if (variant) changes.push(`스타일이 ${vt[variant]}(으)로 바뀐다`);
+        if (variant) changes.push(`변경할 스타일: ${vt[variant]}`);
         parts.push(`탭할 때마다 켜짐/꺼짐이 전환되는 토글 버튼으로 만든다${changes.length ? `(켜졌을 때 ${changes.join(", ")})` : ""}`);
       } else {
         if (label !== undefined) changes.push(`the label becomes ${qe(label)}`);
@@ -599,7 +599,7 @@ function zone(bb: Rect, within: Rect, lang: Lang, phone: boolean): string {
 function rowText(row: LNode[], where: string, lang: Lang, within: Rect): string {
   if (row.length === 1) {
     const d = groupText(row[0].g, lang);
-    return lang === "ja" ? `${where}${d}を置きます。` : lang === "zh" ? `${where}放置${d}。` : lang === "ko" ? `${where} ${d}을(를) 배치합니다.` : `${where}: ${d}.`;
+    return lang === "ja" ? `${where}${d}を置きます。` : lang === "zh" ? `${where}放置${d}。` : lang === "ko" ? `${where} 다음 항목을 배치합니다: ${d}.` : `${where}: ${d}.`;
   }
   const last = row[row.length - 1];
   const fillsRight = last.bb.r >= within.r - 24;
@@ -613,8 +613,8 @@ function rowText(row: LNode[], where: string, lang: Lang, within: Rect): string 
     return `${where}，从左到右横向排成一行：${descs.join("、")}（放在同一行并垂直居中，不要竖着堆叠或换行${stretch}）。`;
   }
   if (lang === "ko") {
-    const stretch = fillsRight ? `, 마지막 ${groupName(last.g, "ko")}은(는) 오른쪽 끝까지 남은 너비를 채웁니다` : "";
-    return `${where}, 왼쪽부터 한 행에 ${descs.join(", ")}을(를) 배치합니다(같은 줄에 세로 중앙 정렬하고 쌓거나 줄 바꿈하지 않음${stretch}).`;
+    const stretch = fillsRight ? `, 마지막 항목(${groupName(last.g, "ko")})은 오른쪽 끝까지 남은 너비를 채웁니다` : "";
+    return `${where}, 왼쪽부터 한 행에 다음 항목을 배치합니다: ${descs.join(", ")}(같은 줄에 세로 중앙 정렬하고 쌓거나 줄 바꿈하지 않음${stretch}).`;
   }
   const stretch = fillsRight ? `; ${groupName(last.g, "en")} stretches to fill the remaining width to the right edge` : "";
   return `${where}, in one row from left to right: ${descs.join(", ")} (keep them on the same line, vertically centered; never stack or wrap them${stretch}).`;
@@ -902,7 +902,7 @@ const FONT_NOTE: Record<Lang, (name: string) => string> = {
   ja: (n) => `書体は ${n} を使う。`,
   en: (n) => `Use ${n} as the typeface.`,
   zh: (n) => `字体使用 ${n}。`,
-  ko: (n) => `글꼴은 ${n}을(를) 사용한다.`,
+  ko: (n) => `사용할 글꼴: ${n}.`,
 };
 
 const THEME_NOTES: Record<Lang, { shape: Record<Theme["shape"], string>; emphasized: string; plainType: string; motion: Record<Theme["motion"], string> }> = {

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -320,9 +320,9 @@ export const SHAPES: { key: ShapeScale; label: string; icon: string }[] = [
 ];
 
 export const FONTS: { key: FontKey; label: string; family: string; /** Google Fonts family to fetch, if any */ google?: string }[] = [
-  { key: "roboto", label: "Roboto", family: "Roboto, system-ui, sans-serif" },
-  { key: "robotoFlex", label: "Roboto Flex", family: "'Roboto Flex', Roboto, system-ui, sans-serif", google: "Roboto+Flex:wght@400;500;600;700" },
-  { key: "robotoSerif", label: "Roboto Serif", family: "'Roboto Serif', Georgia, serif", google: "Roboto+Serif:wght@400;500;600;700" },
+  { key: "roboto", label: "Roboto", family: "Roboto, 'Noto Sans KR', system-ui, sans-serif" },
+  { key: "robotoFlex", label: "Roboto Flex", family: "'Roboto Flex', Roboto, 'Noto Sans KR', system-ui, sans-serif", google: "Roboto+Flex:wght@400;500;600;700" },
+  { key: "robotoSerif", label: "Roboto Serif", family: "'Roboto Serif', Georgia, 'Noto Sans KR', serif", google: "Roboto+Serif:wght@400;500;600;700" },
   { key: "system", label: "System", family: "system-ui, -apple-system, 'Segoe UI', sans-serif" },
 ];
 

--- a/tests/language.cjs
+++ b/tests/language.cjs
@@ -1,0 +1,104 @@
+// Run against `npm run dev`: node tests/language.cjs (Playwright and its Chromium must be available).
+// Set PLAYWRIGHT_CHANNEL=msedge to use an installed Edge browser instead.
+const assert = require('node:assert/strict');
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch({ channel: process.env.PLAYWRIGHT_CHANNEL, headless: true });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, locale: 'en-US' });
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.goto(process.env.TEST_URL || 'http://127.0.0.1:3000');
+    await page.getByTitle('Language', { exact: true }).waitFor();
+    await page.getByText('Home', { exact: true }).first().click();
+    await page.getByTitle('Prompt', { exact: true }).click();
+    const original = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByRole('button', { name: 'Add button', exact: true }).waitFor();
+    const resized = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    assert.deepEqual(resized.groups, original.groups, 'Resizing must not replace canvas parts');
+    assert.deepEqual(resized.frames, original.frames, 'Resizing must not replace screens');
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.getByTitle('Parts', { exact: true }).waitFor();
+    const languages = [
+      { key: 'ko', name: '한국어', menu: '언어', parts: '부품', favorite: '즐겨찾기', title: '제목', prompt: '프롬프트' },
+      { key: 'ja', name: '日本語', menu: '言語', parts: '部品', favorite: 'お気に入り', title: 'タイトル', prompt: 'プロンプト' },
+      { key: 'zh', name: '中文', menu: '语言', parts: '组件', favorite: '收藏', title: '标题', prompt: '提示词' },
+      { key: 'en', name: 'English', menu: 'Language', parts: 'Parts', favorite: 'Favorite', title: 'Title', prompt: 'Prompt' },
+    ];
+    let menu = 'Language';
+    for (const lang of languages) {
+      await page.getByTitle(menu, { exact: true }).click();
+      await page.getByRole('menuitemradio', { name: lang.name }).click();
+      await page.getByTitle(lang.parts, { exact: true }).waitFor();
+      await page.waitForFunction((key) => document.documentElement.lang === key && JSON.parse(localStorage.getItem('m3e:ui')).lang === key, lang.key);
+      const doc = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+      const items = doc.groups.flatMap((group) => group.items);
+      assert.equal(items.find((item) => item.icon === 'star' && item.kind === 'button').label, lang.favorite);
+      assert.equal(items.find((item) => item.kind === 'topAppBar').label, lang.title);
+      assert.deepEqual(items.map((item) => item.id), original.groups.flatMap((group) => group.items.map((item) => item.id)));
+      const prompt = await page.getByRole('textbox', { name: lang.prompt, exact: true }).inputValue();
+      assert.ok(prompt.includes(lang.favorite), `Prompt did not update for ${lang.key}`);
+      if (lang.key === 'ko') {
+        assert.ok(prompt.includes('구현해 주세요'));
+        const fonts = await page.evaluate(async () => {
+          await document.fonts.ready;
+          return [...document.fonts].filter((font) => font.family === 'Noto Sans KR' && font.status === 'loaded').length;
+        });
+        assert.ok(fonts > 0, 'Korean web font did not load');
+        await page.screenshot({ path: require('node:path').join(require('node:os').tmpdir(), 'm3e-korean.png') });
+      }
+      menu = lang.menu;
+    }
+
+    // Both history stacks must follow language changes without changing their geometry or IDs.
+    await page.getByTitle('Add screen', { exact: true }).click();
+    await page.getByTitle('Undo (Ctrl+Z)', { exact: true }).click();
+    await page.getByTitle('Language', { exact: true }).click();
+    await page.getByRole('menuitemradio', { name: '한국어' }).click();
+    await page.getByTitle('다시 실행 (Ctrl+Shift+Z)', { exact: true }).click();
+    const redone = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    assert.deepEqual(redone.frames.map((frame) => frame.name), ['홈', '화면 2']);
+    assert.ok(redone.groups.flatMap((group) => group.items).some((item) => item.label === '즐겨찾기'));
+    await page.getByTitle('언어', { exact: true }).click();
+    await page.getByRole('menuitemradio', { name: 'English', exact: true }).click();
+    const renamed = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    assert.deepEqual(renamed.frames.map((frame) => frame.name), ['Home', 'Screen 2']);
+    await page.getByTitle('Undo (Ctrl+Z)', { exact: true }).click();
+    const undone = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    assert.deepEqual(undone.groups, original.groups);
+    assert.deepEqual(undone.frames, original.frames);
+
+    // A saved project can mix defaults and authored text, including an edited prompt.
+    await page.evaluate(() => {
+      const doc = JSON.parse(localStorage.getItem('m3e:doc'));
+      doc.groups.flatMap((group) => group.items).find((item) => item.kind === 'button').label = 'My custom button';
+      doc.promptEdit = 'My custom prompt';
+      doc.frames[0].name = 'My custom screen';
+      localStorage.setItem('m3e:doc', JSON.stringify(doc));
+    });
+    await page.reload();
+    await page.getByTitle('Language', { exact: true }).click();
+    await page.getByRole('menuitemradio', { name: '한국어' }).click();
+    await page.getByTitle('부품', { exact: true }).waitFor();
+    const saved = await page.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    assert.ok(saved.groups.flatMap((group) => group.items).some((item) => item.label === 'My custom button'));
+    assert.equal(saved.promptEdit, 'My custom prompt');
+    assert.equal(saved.frames[0].name, 'My custom screen');
+    await page.reload();
+    await page.getByTitle('언어', { exact: true }).waitFor();
+
+    const mobile = await browser.newPage({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true, locale: 'en-US' });
+    await mobile.goto(process.env.TEST_URL || 'http://127.0.0.1:3000');
+    await mobile.getByTitle('Language', { exact: true }).click();
+    await mobile.getByRole('button', { name: '한국어', exact: true }).click();
+    await mobile.getByTitle('언어', { exact: true }).waitFor();
+    const mobileDoc = await mobile.evaluate(() => JSON.parse(localStorage.getItem('m3e:doc')));
+    assert.deepEqual(mobileDoc.groups.flatMap((group) => group.items.map((item) => item.label)), ['즐겨찾기', '공유', '시작하기']);
+    assert.deepEqual(errors, []);
+    console.log('PASS: four-language switching, generated prompt, Korean font, authored text, persistence, and mobile');
+  } finally {
+    await browser.close();
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
## What and why

Add Korean to the editor UI, part defaults, generated Android/Web prompts, and optional AI helper. Load Noto Sans KR as a Hangul fallback and remeasure text when fonts finish loading.

Switching languages now updates built-in example copy, numbered screen names, and undo/redo snapshots together. For example, creating `화면 2`, switching to English, and undoing no longer leaves Korean defaults in an English prompt. Resizing a fresh desktop session to a mobile viewport also preserves the canvas instead of replacing it with the mobile starter layout.

Part/category names, style options, transitions, and background-color labels use the selected language. This is rebased onto the latest main, including Korean text for frame-size presets, navigation rails, and mixed-size/Web prompt guidance.

Existing documents do not track whether text was authored or supplied as a default. Default-copy translation therefore uses exact matches against built-in strings; other custom text and manually edited prompts are preserved.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (static export, after rebasing)
- [x] New or changed UI strings and prompt text exist in Japanese, English, Chinese, and Korean
- [x] Browser QA at desktop and mobile viewport sizes: language switching, generated prompts, Korean font rendering, resize preservation, numbered screen names, undo/redo, custom screen names, and persisted language
- [x] Checked the newly merged desktop preset and its Korean Web prompt in the browser
- [x] Checked all 16 source/target language combinations for default screen-name translation and custom-name preservation

`tests/language.cjs` records the browser regression scenarios. It requires an externally available Playwright installation and Chromium (or `PLAYWRIGHT_CHANNEL=msedge`); no new project dependency or CI workflow is added. The expanded script was syntax-checked; the scenarios above were exercised through interactive browser QA.


## Screenshots

### Korean editor after the fix
Korean menus, component labels, default example text, and generated prompts, with Noto Sans KR font rendering.

<img width="1440" height="1000" alt="korean-editor" src="https://github.com/user-attachments/assets/ed402927-9c9e-4668-a4d4-43b0d3873b78" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Korean as a fourth editor language (alongside Japanese, English, and Chinese) and fixes language switching so built-in copy, screen names, and undo/redo history all update together.

**New Features**
- Localizes UI strings, part defaults, generated Android/Web prompts, and the optional AI helper in Korean.
- Loads Noto Sans KR as a Hangul fallback and remeasures part text once fonts finish loading.
- Switches part/category names, style variants, transitions, and background-color labels with the selected language.
- Adds `tests/language.cjs` covering language switching, prompt output, font rendering, and custom-text preservation, runnable against a local dev server with an external Playwright install.

**Bug Fixes**
- Switching languages now translates default labels, numbered screen names (e.g. "화면 2" ↔ "Screen 2"), past/future undo snapshots, and pending tidy operations together.
- Resizing a fresh desktop session to a mobile viewport keeps the desktop canvas instead of replacing it with the mobile starter layout.
- Since existing documents don't track whether text was authored or default, only copy that exactly matches built-in strings is translated; custom text and edited prompts stay untouched.

<sup>Written for commit dd49e0ccc2d7f31b636e7a8715665d7e2ff4f3dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



