### PR TITLE
Let a host supply document storage and receive the prompt

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -491,8 +491,11 @@ export default function Page() {
     // React's development double-run would otherwise read back its own first save
     if (loadedRef.current) return;
     try {
-      const hosted = host.loadDoc?.();
-      const d = hosted ? null : localStorage.getItem(DOC_KEY);
+      // Branch on whether the host SUPPLIED a loader, not on what it returned: a host that
+      // returns null is saying "no saved document", which must start fresh rather than fall
+      // back to this browser's unrelated standalone copy.
+      const hosted = host.loadDoc ? host.loadDoc() : null;
+      const d = host.loadDoc ? null : localStorage.getItem(DOC_KEY);
       if (hosted) {
         hadDocRef.current = true;
         applyDoc(hosted, false);
@@ -501,9 +504,10 @@ export default function Page() {
         applyDoc(JSON.parse(d) as Partial<Doc>, false);
         // frame mode is decided by the device (media-query effect), not restored
       }
-      const stored = localStorage.getItem(UI_KEY);
+      // Same rule as the document above: only read localStorage when no loader was supplied.
+      const stored = host.loadUi ? null : localStorage.getItem(UI_KEY);
       // `JSON.parse` is untyped here as it was before; every field is checked individually below.
-      const ui = host.loadUi?.() ?? (stored ? JSON.parse(stored) : null);
+      const ui = host.loadUi ? host.loadUi() : stored ? JSON.parse(stored) : null;
       if (ui) {
         if (ui.view) setView(ui.view);
         if (typeof ui.leftOpen === "boolean") setLeftOpen(ui.leftOpen);
@@ -3143,8 +3147,13 @@ export default function Page() {
             onPrompt={async () => {
               try {
                 const text = effectivePrompt(doc, widths, lang);
-                // A host returning true has taken the prompt; one that only observes still gets a copy.
-                if (host.onExport?.(text, doc) === true) return;
+                // A host returning true has taken the prompt; one that only observes still gets a
+                // copy. Its own failure is caught here so a broken hook cannot also break copying.
+                let handled = false;
+                try {
+                  handled = host.onExport?.(text, doc) === true;
+                } catch {}
+                if (handled) return;
                 await navigator.clipboard.writeText(text);
                 showToast(t("copied", lang), 1400, "check");
               } catch {}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -94,6 +94,7 @@ import { ThemeContext, ensureFontLoaded } from "@/lib/theme";
 import { BottomSheet, MobileActionBar, MobileInspector, MobileLang, MobileSettings } from "@/components/Mobile";
 import { ConfirmDialog, IconBtn, Segmented } from "@/components/ui";
 import { Lang, LangContext, isLang, setGlobalLang, t } from "@/lib/i18n";
+import { useHost } from "@/lib/host";
 
 /** the dragged part's own travel: a little lag reads as weight */
 const CARRY = {
@@ -291,6 +292,8 @@ const LEFT_TABS: { key: LeftTab; icon: string; title: "parts" | "layers" | "colo
 ];
 
 export default function Page() {
+  // Optional host hooks; every default below is the standalone behaviour. See lib/host.ts.
+  const host = useHost();
   /* ---------- document ---------- */
   const [groups, setGroups] = useState<Group[]>(seed);
   const [frames, setFrames] = useState<Frame[]>(SEED_FRAMES);
@@ -488,15 +491,20 @@ export default function Page() {
     // React's development double-run would otherwise read back its own first save
     if (loadedRef.current) return;
     try {
-      const d = localStorage.getItem(DOC_KEY);
-      if (d) {
+      const hosted = host.loadDoc?.();
+      const d = hosted ? null : localStorage.getItem(DOC_KEY);
+      if (hosted) {
+        hadDocRef.current = true;
+        applyDoc(hosted, false);
+      } else if (d) {
         hadDocRef.current = true;
         applyDoc(JSON.parse(d) as Partial<Doc>, false);
         // frame mode is decided by the device (media-query effect), not restored
       }
-      const u = localStorage.getItem(UI_KEY);
-      if (u) {
-        const ui = JSON.parse(u);
+      const stored = localStorage.getItem(UI_KEY);
+      // `JSON.parse` is untyped here as it was before; every field is checked individually below.
+      const ui = host.loadUi?.() ?? (stored ? JSON.parse(stored) : null);
+      if (ui) {
         if (ui.view) setView(ui.view);
         if (typeof ui.leftOpen === "boolean") setLeftOpen(ui.leftOpen);
         if (typeof ui.rightOpen === "boolean") setRightOpen(ui.rightOpen);
@@ -592,29 +600,18 @@ export default function Page() {
   useEffect(() => {
     if (!loadedRef.current) return;
     try {
-      localStorage.setItem(
-        DOC_KEY,
-        JSON.stringify({ groups, frames, paletteKey, frame, title, brief, promptEdit, platform: platform ?? undefined, customPalette: customPalette ?? undefined, dynamicColor, theme }),
-      );
+      const payload = { groups, frames, paletteKey, frame, title, brief, promptEdit, platform: platform ?? undefined, customPalette: customPalette ?? undefined, dynamicColor, theme };
+      if (host.saveDoc) host.saveDoc(payload as Partial<Doc>);
+      else localStorage.setItem(DOC_KEY, JSON.stringify(payload));
     } catch {}
   }, [groups, frames, paletteKey, frame, title, brief, promptEdit, platform, customPalette, dynamicColor, theme]);
 
   useEffect(() => {
     if (!loadedRef.current) return;
     try {
-      localStorage.setItem(
-        UI_KEY,
-        JSON.stringify({
-          view,
-          leftOpen,
-          rightOpen,
-          leftW,
-          rightW,
-          favorites,
-          mode,
-          lang,
-        }),
-      );
+      const ui = { view, leftOpen, rightOpen, leftW, rightW, favorites, mode, lang };
+      if (host.saveUi) host.saveUi(ui);
+      else localStorage.setItem(UI_KEY, JSON.stringify(ui));
     } catch {}
   }, [
     view,
@@ -3145,7 +3142,10 @@ export default function Page() {
             onLangSheet={() => setSheet(sheet === "lang" ? null : "lang")}
             onPrompt={async () => {
               try {
-                await navigator.clipboard.writeText(effectivePrompt(doc, widths, lang));
+                const text = effectivePrompt(doc, widths, lang);
+                // A host returning true has taken the prompt; one that only observes still gets a copy.
+                if (host.onExport?.(text, doc) === true) return;
+                await navigator.clipboard.writeText(text);
                 showToast(t("copied", lang), 1400, "check");
               } catch {}
             }}

--- a/lib/host.ts
+++ b/lib/host.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { Doc } from "./tokens";
+
+/**
+ * Hooks for an application that embeds the editor.
+ *
+ * The editor keeps its own state and its own UI; a host only needs to say where the document is kept
+ * and where the prompt goes. Every field is optional and every default is what the standalone app
+ * already did — localStorage for the document, the clipboard for the prompt — so an editor rendered
+ * without a provider behaves exactly as before.
+ *
+ * ```tsx
+ * <HostProvider value={{ loadDoc, saveDoc, onExport: (text) => sendToAgent(text) }}>
+ *   <Canvas />
+ * </HostProvider>
+ * ```
+ */
+export type HostAdapter = {
+  /** Return the saved document, or null for a fresh one. Omit to read localStorage. */
+  loadDoc?: () => Partial<Doc> | null;
+  /** Persist the document. Omit to write localStorage. Called on every change, so debounce if remote. */
+  saveDoc?: (doc: Partial<Doc>) => void;
+
+  /** Editor chrome — panel widths, favourites. Separate from the document because it is not the work. */
+  loadUi?: () => unknown | null;
+  saveUi?: (ui: unknown) => void;
+
+  /**
+   * Where the generated prompt goes.
+   *
+   * Return `true` to say the host has handled it and the editor should not also write the clipboard;
+   * anything else and the clipboard write still happens. That default matters — a host that only
+   * wants to observe the export does not have to reimplement copying.
+   */
+  onExport?: (prompt: string, doc: Doc) => boolean | void;
+};
+
+const EMPTY: HostAdapter = {};
+
+export const HostContext = createContext<HostAdapter>(EMPTY);
+
+export const HostProvider = HostContext.Provider;
+
+export const useHost = (): HostAdapter => useContext(HostContext);


### PR DESCRIPTION
## What and why

Refs #55 — the smaller of the two options in that issue.

`lib/host.ts` adds an optional React context the editor reads for two things: where the
document is kept, and where the generated prompt goes.

```ts
type HostAdapter = {
  loadDoc?: () => Partial<Doc> | null;
  saveDoc?: (doc: Partial<Doc>) => void;
  loadUi?:  () => unknown | null;
  saveUi?:  (ui: unknown) => void;
  onExport?: (prompt: string, doc: Doc) => boolean | void;
};
```

Every field is optional and every default is the current behaviour — `localStorage` for the
document and the UI, the clipboard for the prompt. **Rendered without a provider the editor is
unchanged**, so this is lifting the hardcoding rather than adding a second use case to support.

`onExport` returns `true` when the host has taken the prompt; anything else and the clipboard
write still runs. That way a host that only wants to *observe* the export does not have to
reimplement copying.

### What I deliberately did not do

The issue proposed extracting the editor into `components/Canvas.tsx` with `app/page.tsx` as a
thin wrapper. I built that first and then dropped it: because `app/page.tsx` has to keep
existing as the route, git cannot record it as a rename, and GitHub shows ~3,400 lines changed
for what is a file move. That seemed a poor trade against a ~25 line idea, and CONTRIBUTING asks
for small focused PRs.

Happy to send the move as a separate PR if you want the editor importable from outside `app/` —
it is mechanical, since `page.tsx` has no relative imports.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] No new or changed UI strings or prompt text — this adds no user-visible copy, so there is
      nothing to translate into ja / en / zh
- [ ] **Not** exercised interactively. `npm ci`, `typecheck` and `build` all pass, and both
      `m3e:doc` and `m3e:ui` are still in the built bundle so the standalone path is intact — but
      the sandboxed browser on this machine could not launch, so I have not clicked through the
      editor or tried the phone layout. Worth a look from someone who can.

Both checks were run before the change as well, so the baseline is known green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional React context (`lib/host.ts`) so an embedding host can supply document storage and receive the generated prompt, while the standalone editor keeps its current behavior.

- Every `HostAdapter` field is optional; defaults remain `localStorage` for the document/UI and the clipboard for the prompt.
- A host that supplies `loadDoc`/`loadUi` and returns `null` now starts fresh instead of falling back to the browser's standalone `localStorage` copy.
- `onExport` returning `true` skips the clipboard write; anything else still copies, and a throwing hook can no longer swallow the write.
- Implements the smaller option from issue #55; the proposed `Canvas.tsx` extraction was dropped to keep the diff small.
- Changes compile and build cleanly but were not exercised interactively — worth a click-through.

<sup>Written for commit 1956476bbd2883b0b143de94fc98ab62de72fe1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

