### PR TITLE
Add Vitest unit tests for the pure lib modules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 ## How I checked it
 
 - [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
 - [ ] `npm run build` passes
 - [ ] New or changed UI strings and prompt text exist in Japanese, English and Chinese
 - [ ] Tried it in the editor (and on a phone, if the change touches the phone editor)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run typecheck
+      - run: npm test
       - run: npm run build
         env:
           NEXT_PUBLIC_BASE_PATH: /${{ github.event.repository.name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ changes and send code. Japanese and Chinese summaries are at the end.
 npm install
 npm run dev        # http://localhost:3000
 npm run typecheck  # tsc --noEmit
+npm test           # Vitest unit tests
 npm run build      # static export into out/
 ```
 
@@ -62,7 +63,7 @@ A new kind touches all of these; the existing kinds are the reference:
 ## Pull requests
 
 - Branch from `main` in your fork.
-- Run `npm run typecheck` and `npm run build`; CI runs the same two on every PR.
+- Run `npm run typecheck`, `npm test` and `npm run build`; CI runs the same three on every PR.
 - Fill in the PR template: what changed, why, and how you checked it. Screenshots
   help for anything visual.
 - By contributing you agree that your changes are licensed under the project's
@@ -74,7 +75,7 @@ A new kind touches all of these; the existing kinds are the reference:
 - 新しい部品やパネル、プロンプトの文言など大きめの変更は、先に Issue で相談してください。
 - 質問やアイデアは Discussions へ。
 - コードのコメントは英語で書きます。UI の文言とプロンプト文は日本語・英語・中国語の 3 言語すべてに追加してください。
-- PR の前に `npm run typecheck` と `npm run build` を通してください。CI でも同じものが走ります。
+- PR の前に `npm run typecheck`、`npm test`、`npm run build` を通してください。CI でも同じものが走ります。
 - 貢献したコードは MIT ライセンスで公開されます。
 
 ## 中文
@@ -83,5 +84,5 @@ A new kind touches all of these; the existing kinds are the reference:
 - 新组件、新面板、提示词措辞等较大的改动，请先开 Issue 讨论。
 - 提问和想法请到 Discussions。
 - 代码注释用英文。UI 文字和提示词需同时提供日文、英文、中文三种语言。
-- 提交 PR 前请运行 `npm run typecheck` 和 `npm run build`，CI 会执行同样的检查。
+- 提交 PR 前请运行 `npm run typecheck`、`npm test` 和 `npm run build`，CI 会执行同样的检查。
 - 贡献的代码以 MIT 许可证发布。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,7 @@ npm test           # Vitest unit tests
 npm run build      # static export into out/
 ```
 
-Node 22 is what CI uses. The app is a single Next.js page with no server; everything
-is stored in the browser.
+Node 22.12 or newer is required (the test suite needs it); CI uses Node 22. The app is a single Next.js page with no server; everything is stored in the browser.
 
 ## Where things live
 

--- a/lib/color.test.ts
+++ b/lib/color.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+
+import { isHex } from "./color";
+
+describe("isHex", () => {
+  it("accepts a six-digit hex color with a leading #", () => {
+    expect(isHex("#6750A4")).toBe(true);
+    expect(isHex("#ff0088")).toBe(true);
+  });
+
+  it("rejects shorthand, missing #, and non-hex input", () => {
+    expect(isHex("#fff")).toBe(false);
+    expect(isHex("6750A4")).toBe(false);
+    expect(isHex("#GGGGGG")).toBe(false);
+  });
+});

--- a/lib/color.test.ts
+++ b/lib/color.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 
-import { isHex } from "./color";
+import { hexToRgb, isHex, onColorFor, rgbToHex, rgbToLab, schemeFromSeed } from "./color";
+
+/** perceptual lightness of a hex color, for readable-contrast assertions */
+const toneOf = (hex: string) => rgbToLab(...hexToRgb(hex)!).L;
 
 describe("isHex", () => {
   it("accepts a six-digit hex color with a leading #", () => {
@@ -12,5 +15,65 @@ describe("isHex", () => {
     expect(isHex("#fff")).toBe(false);
     expect(isHex("6750A4")).toBe(false);
     expect(isHex("#GGGGGG")).toBe(false);
+  });
+});
+
+describe("hexToRgb / rgbToHex", () => {
+  it("parses a hex color into channels", () => {
+    expect(hexToRgb("#6750A4")).toEqual([103, 80, 164]);
+    expect(hexToRgb("6750a4")).toEqual([103, 80, 164]);
+  });
+
+  it("round-trips any channel values through both directions", () => {
+    for (const [r, g, b] of [[0, 0, 0], [255, 255, 255], [103, 80, 164], [18, 250, 199]] as const) {
+      expect(hexToRgb(rgbToHex(r, g, b))).toEqual([r, g, b]);
+    }
+  });
+
+  it("clamps channels outside 0..255 when formatting", () => {
+    expect(rgbToHex(300, -4, 7.6)).toBe("#FF0008");
+  });
+
+  it("returns null for input that is not a hex color", () => {
+    expect(hexToRgb("#XYZ123")).toBeNull();
+    expect(hexToRgb("#ABC")).toBeNull();
+  });
+});
+
+describe("schemeFromSeed", () => {
+  const seed = "#6750A4";
+
+  it("honours the dark option: surfaces go dark, text on them light", () => {
+    const light = schemeFromSeed(seed);
+    const dark = schemeFromSeed(seed, "Custom", { dark: true });
+    expect(toneOf(dark.surface)).toBeLessThan(toneOf(light.surface));
+    expect(toneOf(dark.onSurface)).toBeGreaterThan(toneOf(light.onSurface));
+  });
+
+  it("honours the contrast option: high contrast pushes the accent further from the surface", () => {
+    const standard = schemeFromSeed(seed);
+    const high = schemeFromSeed(seed, "Custom", { contrast: "high" });
+    expect(high.primary).not.toBe(standard.primary);
+    expect(Math.abs(toneOf(high.primary) - toneOf(high.surface))).toBeGreaterThan(
+      Math.abs(toneOf(standard.primary) - toneOf(standard.surface)),
+    );
+  });
+});
+
+describe("onColorFor", () => {
+  it("picks a dark on-color on a light background", () => {
+    const on = onColorFor("#FFFFFF");
+    expect(isHex(on)).toBe(true);
+    expect(toneOf(on)).toBeLessThan(40);
+  });
+
+  it("picks a light on-color on a dark background", () => {
+    const on = onColorFor("#000000");
+    expect(isHex(on)).toBe(true);
+    expect(toneOf(on)).toBeGreaterThan(90);
+  });
+
+  it("falls back to black when the background cannot be parsed", () => {
+    expect(onColorFor("nope")).toBe("#000000");
   });
 });

--- a/lib/i18n.test.ts
+++ b/lib/i18n.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+
+import { isLang, LANGS } from "./i18n";
+
+describe("isLang", () => {
+  it("accepts every language the UI offers", () => {
+    for (const { key } of LANGS) expect(isLang(key)).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isLang("fr")).toBe(false);
+    expect(isLang(undefined)).toBe(false);
+  });
+});

--- a/lib/prompt.test.ts
+++ b/lib/prompt.test.ts
@@ -77,7 +77,6 @@ describe("buildPrompt structure", () => {
     const web = lines(build(lang, "web"));
     expect(android[2]).toBe(PLATFORM_LINE[lang].android);
     expect(web[2]).toBe(PLATFORM_LINE[lang].web);
-    expect(android[2]).not.toBe(web[2]);
   });
 
   it("names Android when the doc picks no platform", () => {
@@ -88,7 +87,7 @@ describe("buildPrompt structure", () => {
 
   it.each(LANGS)("writes one style note per part kind in use in %s", (lang) => {
     expect(styleBullets(build(lang), lang)).toHaveLength(3); // topAppBar, button, bottomNav
-    const chip: Item = { ...makeItem("chip"), id: "chip", label: "New" };
+    const chip: Item = { ...makeItem("chip"), id: "chip" };
     expect(styleBullets(build(lang, "android", [chip]), lang)).toHaveLength(4);
   });
 

--- a/lib/prompt.test.ts
+++ b/lib/prompt.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Lang, setGlobalLang } from "./i18n";
+import { buildPrompt } from "./prompt";
+import { BACK_TARGET, Doc, Item, Platform, defaultTabs, makeItem } from "./tokens";
+
+const LANGS: Lang[] = ["ja", "en", "zh"];
+
+/* Section headings in the order buildPrompt must emit them. */
+const SECTIONS: Record<Lang, string[]> = {
+  ja: ["## カラー", "## 形・文字・動き", "## 画面構成", "## 振る舞いと画面遷移", "## 各部品のスタイル", "## 全体の指針"],
+  en: ["## Colors", "## Shape, type and motion", "## Layout", "## Behavior and navigation", "## Component styles", "## General guidance"],
+  zh: ["## 配色", "## 形状、字体与动效", "## 屏幕结构", "## 行为与屏幕跳转", "## 各组件的样式", "## 整体原则"],
+};
+
+const PLATFORM_LINE: Record<Lang, Record<Platform, string>> = {
+  ja: { android: "実装先は Android（ネイティブアプリ）です。", web: "実装先は Web（ブラウザで動くアプリ）です。" },
+  en: { android: "Build it for Android, as a native app.", web: "Build it for the web, as an app that runs in the browser." },
+  zh: { android: "实现目标是 Android（原生应用）。", web: "实现目标是 Web（在浏览器中运行的应用）。" },
+};
+
+/* One phone screen with a top app bar, a connected pair of buttons (one with a
+ * tap action) and a navigation bar. makeItem / defaultTabs fill in the defaults;
+ * module-level language is set first so those defaults follow the test. */
+function fixture(platform: Platform = "android", extraItems: Item[] = []): Doc {
+  const bar: Item = { ...makeItem("topAppBar"), id: "bar", label: "Home" };
+  const save: Item = { ...makeItem("button"), id: "save", label: "Save", action: { to: BACK_TARGET, transition: "fade" } };
+  const cancel: Item = { ...makeItem("button"), id: "cancel", label: "Cancel", variant: "text" };
+  const nav: Item = { ...makeItem("bottomNav"), id: "nav", tabs: defaultTabs() };
+  return {
+    groups: [
+      { id: "g-bar", x: 16, y: 24, axis: "x", items: [bar] },
+      { id: "g-row", x: 16, y: 400, axis: "x", items: [save, cancel, ...extraItems] },
+      { id: "g-nav", x: 16, y: 812, axis: "x", items: [nav] },
+    ],
+    frames: [{ id: "f-home", name: "Home", x: 0, y: 0 }],
+    paletteKey: "purple",
+    frame: "phone",
+    platform,
+    title: "Notes",
+    brief: "",
+  };
+}
+
+/* Set the module-level language for the fixture helpers, then build explicitly
+ * in that language — nothing is left to ambient state. */
+function build(lang: Lang, platform: Platform = "android", extraItems: Item[] = []) {
+  setGlobalLang(lang);
+  return buildPrompt(fixture(platform, extraItems), {}, undefined, lang);
+}
+
+const lines = (prompt: string) => prompt.split("\n");
+const headings = (prompt: string) => lines(prompt).filter((l) => l.startsWith("## "));
+/* bullet lines between the style heading and the closing guidance heading */
+function styleBullets(prompt: string, lang: Lang) {
+  const ls = lines(prompt);
+  const style = ls.indexOf(SECTIONS[lang][4]);
+  const general = ls.indexOf(SECTIONS[lang][5]);
+  return ls.slice(style + 1, general).filter((l) => l.startsWith("- "));
+}
+
+const QUOTED: Record<Lang, { label: string; others: string[] }> = {
+  ja: { label: "「Save」", others: ['"Save"', "“Save”"] },
+  en: { label: '"Save"', others: ["「Save」", "“Save”"] },
+  zh: { label: "“Save”", others: ["「Save」", '"Save"'] },
+};
+
+describe("buildPrompt structure", () => {
+  afterEach(() => setGlobalLang("ja")); // restore the module default
+
+  it.each(LANGS)("orders its sections the same way in %s", (lang) => {
+    expect(headings(build(lang))).toEqual(SECTIONS[lang]);
+  });
+
+  it.each(LANGS)("names the requested platform on the intro lines in %s", (lang) => {
+    const android = lines(build(lang, "android"));
+    const web = lines(build(lang, "web"));
+    expect(android[2]).toBe(PLATFORM_LINE[lang].android);
+    expect(web[2]).toBe(PLATFORM_LINE[lang].web);
+    expect(android[2]).not.toBe(web[2]);
+  });
+
+  it("names Android when the doc picks no platform", () => {
+    setGlobalLang("en");
+    const { platform, ...doc } = fixture();
+    expect(lines(buildPrompt(doc, {}, undefined, "en"))[2]).toBe(PLATFORM_LINE.en.android);
+  });
+
+  it.each(LANGS)("writes one style note per part kind in use in %s", (lang) => {
+    expect(styleBullets(build(lang), lang)).toHaveLength(3); // topAppBar, button, bottomNav
+    const chip: Item = { ...makeItem("chip"), id: "chip", label: "New" };
+    expect(styleBullets(build(lang, "android", [chip]), lang)).toHaveLength(4);
+  });
+
+  it.each(LANGS)("quotes labels with %s punctuation", (lang) => {
+    const prompt = build(lang);
+    expect(prompt).toContain(QUOTED[lang].label);
+    for (const other of QUOTED[lang].others) expect(prompt).not.toContain(other);
+  });
+
+  it("follows its lang argument regardless of ambient module state", () => {
+    setGlobalLang("en");
+    const doc = fixture();
+    setGlobalLang("zh");
+    const prompt = buildPrompt(doc, {}, undefined, "ja");
+    expect(headings(prompt)).toEqual(SECTIONS.ja);
+    expect(prompt).toContain("「Save」");
+  });
+});

--- a/lib/shapes.test.ts
+++ b/lib/shapes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { DURATION_PER_SHAPE_MS, LoadingAnimator, SHAPE_COUNT, Spring, getShapes, morphedShape } from "./shapes";
+
+describe("getShapes", () => {
+  it("samples every shape in the sequence with the same point count", () => {
+    const shapes = getShapes();
+    expect(shapes).toHaveLength(SHAPE_COUNT);
+    const n = shapes[0].length;
+    expect(n).toBeGreaterThan(0);
+    for (const s of shapes) expect(s).toHaveLength(n);
+  });
+
+  it("normalizes every shape into the unit box, up to resampling drift", () => {
+    for (const shape of getShapes()) {
+      let extreme = 0;
+      for (const [x, y] of shape) {
+        expect(Math.abs(x)).toBeLessThanOrEqual(1 + 1e-9);
+        expect(Math.abs(y)).toBeLessThanOrEqual(1 + 1e-9);
+        extreme = Math.max(extreme, Math.abs(x), Math.abs(y));
+      }
+      /* resampling along the arc can step just past the exact extreme vertex */
+      expect(extreme).toBeGreaterThan(0.99);
+    }
+  });
+
+  it("caches the sampled shapes", () => {
+    expect(getShapes()).toBe(getShapes());
+  });
+});
+
+describe("morphedShape", () => {
+  it("returns a shape exactly at every whole fraction", () => {
+    const shapes = getShapes();
+    for (let i = 0; i < SHAPE_COUNT; i++) expect(morphedShape(i)).toEqual(shapes[i]);
+  });
+
+  it("interpolates halfway between neighbours at a half fraction", () => {
+    const [a, b] = getShapes();
+    const mid = morphedShape(0.5);
+    expect(mid[0]).toEqual([(a[0][0] + b[0][0]) / 2, (a[0][1] + b[0][1]) / 2]);
+  });
+
+  it("wraps around the sequence, past both ends", () => {
+    expect(morphedShape(SHAPE_COUNT)).toEqual(getShapes()[0]);
+    const shapes = getShapes();
+    const [last, first] = [shapes[SHAPE_COUNT - 1], shapes[0]];
+    const mid = morphedShape(-0.5);
+    expect(mid[0]).toEqual([(last[0][0] + first[0][0]) / 2, (last[0][1] + first[0][1]) / 2]);
+  });
+});
+
+describe("Spring", () => {
+  it("settles at its target", () => {
+    const s = new Spring(200, 0.6);
+    s.target = 1;
+    for (let i = 0; i < 600; i++) s.step(1 / 60);
+    expect(s.pos).toBeCloseTo(1, 2);
+    expect(Math.abs(s.vel)).toBeLessThan(0.01);
+  });
+
+  it("overshoots when underdamped, not when critically damped", () => {
+    const peakAfter = (damping: number) => {
+      const s = new Spring(200, damping);
+      s.target = 1;
+      let peak = 0;
+      for (let i = 0; i < 120; i++) {
+        s.step(1 / 60);
+        peak = Math.max(peak, s.pos);
+      }
+      return peak;
+    };
+    expect(peakAfter(0.6)).toBeGreaterThan(1);
+    expect(peakAfter(1)).toBeLessThanOrEqual(1.001);
+  });
+});
+
+describe("LoadingAnimator", () => {
+  it("advances the morph with time while keeping rotation inside one turn", () => {
+    const a = new LoadingAnimator();
+    for (let ts = 0; ts <= 3 * DURATION_PER_SHAPE_MS; ts += 50) {
+      a.update(ts);
+      expect(a.rotation).toBeGreaterThanOrEqual(0);
+      expect(a.rotation).toBeLessThan(360);
+    }
+    expect(a.morph).toBeGreaterThan(0);
+  });
+
+  it("is deterministic for identical frame sequences", () => {
+    const a = new LoadingAnimator();
+    const b = new LoadingAnimator();
+    for (let ts = 0; ts <= 2000; ts += 33) {
+      a.update(ts);
+      b.update(ts);
+    }
+    expect(a.morph).toBe(b.morph);
+    expect(a.rotation).toBe(b.rotation);
+  });
+});

--- a/lib/tidy.test.ts
+++ b/lib/tidy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { tidyFrame } from "./tidy";
+import { Frame, Group, Item, Kind, NAV_BAR_H, PHONE_H, PHONE_MARGIN, PHONE_W, makeItem } from "./tokens";
+
+const frame: Frame = { id: "f1", name: "Home", x: 0, y: 0 };
+const frames = [frame];
+
+const grp = (id: string, x: number, y: number, items: Item[]): Group => ({ id, x, y, axis: "x", items });
+const part = (kind: Kind, id: string): Item => ({ ...makeItem(kind), id });
+
+describe("tidyFrame", () => {
+  it("snaps the app bar to the top edge and the navigation bar to the bottom", () => {
+    const groups = [grp("g-bar", 40, 300, [part("topAppBar", "bar")]), grp("g-nav", 40, 100, [part("bottomNav", "nav")])];
+    const out = tidyFrame(groups, frame, frames, {});
+    expect(out).not.toBeNull();
+    const bar = out!.find((g) => g.id === "g-bar")!;
+    const nav = out!.find((g) => g.id === "g-nav")!;
+    expect([bar.x, bar.y]).toEqual([0, 0]);
+    expect([nav.x, nav.y]).toEqual([0, PHONE_H - (80 + NAV_BAR_H)]);
+  });
+
+  it("moves a FAB to the bottom-right corner, one margin in", () => {
+    const out = tidyFrame([grp("g-fab", 40, 100, [part("fab", "fab")])], frame, frames, {});
+    expect(out).not.toBeNull();
+    expect([out![0].x, out![0].y]).toEqual([PHONE_W - PHONE_MARGIN - 56, PHONE_H - PHONE_MARGIN - 56]);
+  });
+
+  it("joins neighbouring buttons into one connected run in reading order", () => {
+    const out = tidyFrame([grp("g1", 16, 300, [part("button", "b1")]), grp("g2", 150, 300, [part("button", "b2")])], frame, frames, {});
+    expect(out).toHaveLength(1);
+    expect(out![0].items.map((it) => it.id)).toEqual(["b1", "b2"]);
+  });
+
+  it("joins neighbouring list items into one connected column", () => {
+    const out = tidyFrame([grp("g1", 16, 100, [part("listItem", "l1")]), grp("g2", 16, 180, [part("listItem", "l2")])], frame, frames, {});
+    expect(out).toHaveLength(1);
+    expect(out![0].axis).toBe("y");
+    expect(out![0].items.map((it) => it.id)).toEqual(["l1", "l2"]);
+  });
+
+  it("returns null for a frame that is already tidy", () => {
+    const messy = [grp("g-bar", 40, 300, [part("topAppBar", "bar")]), grp("g-fab", 10, 10, [part("fab", "fab")])];
+    const once = tidyFrame(messy, frame, frames, {});
+    expect(once).not.toBeNull();
+    expect(tidyFrame(once!, frame, frames, {})).toBeNull();
+  });
+});

--- a/lib/tidy.test.ts
+++ b/lib/tidy.test.ts
@@ -13,7 +13,6 @@ describe("tidyFrame", () => {
   it("snaps the app bar to the top edge and the navigation bar to the bottom", () => {
     const groups = [grp("g-bar", 40, 300, [part("topAppBar", "bar")]), grp("g-nav", 40, 100, [part("bottomNav", "nav")])];
     const out = tidyFrame(groups, frame, frames, {});
-    expect(out).not.toBeNull();
     const bar = out!.find((g) => g.id === "g-bar")!;
     const nav = out!.find((g) => g.id === "g-nav")!;
     expect([bar.x, bar.y]).toEqual([0, 0]);
@@ -22,7 +21,6 @@ describe("tidyFrame", () => {
 
   it("moves a FAB to the bottom-right corner, one margin in", () => {
     const out = tidyFrame([grp("g-fab", 40, 100, [part("fab", "fab")])], frame, frames, {});
-    expect(out).not.toBeNull();
     expect([out![0].x, out![0].y]).toEqual([PHONE_W - PHONE_MARGIN - 56, PHONE_H - PHONE_MARGIN - 56]);
   });
 

--- a/lib/tokens.test.ts
+++ b/lib/tokens.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_THEME, R_FULL, baseRadii, getShape, makeItem, normalizeTheme, runCorners, scaleR, setGlobalShape } from "./tokens";
+import { DEFAULT_THEME, R_FULL, baseRadii, makeItem, normalizeTheme, runCorners, scaleR, setGlobalShape } from "./tokens";
 
 afterEach(() => setGlobalShape("rounded")); // restore the module default
 
@@ -66,8 +66,4 @@ describe("normalizeTheme", () => {
     expect(t.font).toBe(DEFAULT_THEME.font);
     expect(t.shape).toBe(DEFAULT_THEME.shape);
   });
-});
-
-it("restores the default shape scale between tests", () => {
-  expect(getShape()).toBe("rounded");
 });

--- a/lib/tokens.test.ts
+++ b/lib/tokens.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_THEME, R_FULL, baseRadii, getShape, makeItem, normalizeTheme, runCorners, scaleR, setGlobalShape } from "./tokens";
+
+afterEach(() => setGlobalShape("rounded")); // restore the module default
+
+describe("setGlobalShape / scaleR", () => {
+  it("shrinks radii for the square scale and grows them for full", () => {
+    setGlobalShape("square");
+    expect(scaleR(R_FULL)).toBe(Math.round(R_FULL * 0.35));
+    setGlobalShape("full");
+    expect(scaleR(R_FULL)).toBe(Math.round(R_FULL * 1.6));
+    setGlobalShape("rounded");
+    expect(scaleR(R_FULL)).toBe(R_FULL);
+  });
+
+  it("flows into a part's default corners", () => {
+    setGlobalShape("rounded");
+    const rounded = baseRadii(makeItem("button")).tl;
+    setGlobalShape("square");
+    expect(baseRadii(makeItem("button")).tl).toBeLessThan(rounded);
+    setGlobalShape("full");
+    expect(baseRadii(makeItem("button")).tl).toBeGreaterThan(rounded);
+  });
+
+  it("keeps a radius the author typed in, whatever the scale", () => {
+    const card = { ...makeItem("card"), radiusTop: 12 };
+    setGlobalShape("full");
+    expect(baseRadii(card)).toEqual({ tl: 12, tr: 12, bl: 12, br: 12 });
+  });
+});
+
+describe("runCorners", () => {
+  const outer = 28;
+  const inner = 8;
+
+  it("puts the outer corners at the ends of a horizontal run, inner between parts", () => {
+    expect(runCorners("x", true, false, outer, inner)).toEqual({ tl: outer, bl: outer, tr: inner, br: inner });
+    expect(runCorners("x", false, true, outer, inner)).toEqual({ tl: inner, bl: inner, tr: outer, br: outer });
+  });
+
+  it("puts the outer corners at the ends of a vertical run, inner between parts", () => {
+    expect(runCorners("y", true, false, outer, inner)).toEqual({ tl: outer, tr: outer, bl: inner, br: inner });
+    expect(runCorners("y", false, true, outer, inner)).toEqual({ tl: inner, tr: inner, bl: outer, br: outer });
+  });
+
+  it("rounds a lone part all over and a middle part nowhere", () => {
+    expect(runCorners("x", true, true, outer, inner)).toEqual({ tl: outer, tr: outer, bl: outer, br: outer });
+    expect(runCorners("y", false, false, outer, inner)).toEqual({ tl: inner, tr: inner, bl: inner, br: inner });
+  });
+});
+
+describe("normalizeTheme", () => {
+  it("returns the defaults untouched for undefined or empty input", () => {
+    expect(normalizeTheme(undefined)).toEqual(DEFAULT_THEME);
+    expect(normalizeTheme({})).toEqual(DEFAULT_THEME);
+  });
+
+  it("keeps the valid fields of a partial theme and fills in the rest", () => {
+    expect(normalizeTheme({ dark: true, shape: "full" })).toEqual({ ...DEFAULT_THEME, dark: true, shape: "full" });
+  });
+
+  it("replaces unknown option values with the default", () => {
+    const t = normalizeTheme({ contrast: "blaring" as never, font: "papyrus" as never, shape: "pointy" as never });
+    expect(t.contrast).toBe(DEFAULT_THEME.contrast);
+    expect(t.font).toBe(DEFAULT_THEME.font);
+    expect(t.shape).toBe(DEFAULT_THEME.shape);
+  });
+});
+
+it("restores the default shape scale between tests", () => {
+  expect(getShape()).toBe("rounded");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "m3e",
+  "name": "m3e-canvas",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "m3e",
+      "name": "m3e-canvas",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -21,7 +21,8 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
-        "typescript": "^7"
+        "typescript": "^7",
+        "vitest": "^5.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -732,6 +733,313 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -1077,6 +1385,31 @@
         "postcss": "^8.5.16",
         "tailwindcss": "4.3.3"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.4.0",
@@ -1448,6 +1781,64 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
@@ -1479,6 +1870,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -1517,6 +1918,51 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/framer-motion": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.1.tgz",
@@ -1538,6 +1984,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -1970,11 +2432,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.26",
@@ -2024,6 +2513,41 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
       }
     },
     "node_modules/scheduler": {
@@ -2095,6 +2619,13 @@
         }
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2103,6 +2634,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -2146,6 +2691,43 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tslib": {
@@ -2195,6 +2777,480 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "npx serve out",
-    "typecheck": "tsc --noEmit -p ."
+    "typecheck": "tsc --noEmit -p .",
+    "test": "vitest run"
   },
   "dependencies": {
     "html-to-image": "^1.11.13",
@@ -21,7 +22,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^7"
+    "typescript": "^7",
+    "vitest": "^5.0.0"
   },
   "description": "Sketch Material 3 Expressive screens in the browser and turn them into vibe-coding prompts.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "m3e-canvas",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## What and why

Fixes #6

The repo had no test suite: CI ran typecheck and build only, and regressions in the pure `lib/` logic (prompt generation, tidy layout, color schemes, shape animation) were silent. This PR adds Vitest and covers all five pure modules. Scope stays pure: `ai.ts`, `project.ts` and `theme.ts` (`localStorage` / `fetch` / `document`) are deliberately out.

**What's tested:**

- **`prompt.ts`** — structural assertions only, no snapshots, per the maintainer's ask: heading order in all three languages, the platform line for Android vs Web targets (plus the default fallback), one style note per part kind in use, and per-language quotation marks
- **`tidy.ts`** — bars snap to the frame edges, the FAB moves to the bottom-right corner, neighbouring buttons / list items join into connected runs, and already-tidy input is a no-op (`tidyFrame` returns null)
- **`tokens.ts`** — `setGlobalShape` drives `scaleR` / `baseRadii` while author-typed radii are kept; `runCorners` puts outer corners at the run ends and inner corners between connected parts; `normalizeTheme` fills defaults and rejects unknown option values
- **`color.ts`** — `isHex`, `hexToRgb` / `rgbToHex` round-trip and clamping, `schemeFromSeed` honours its `dark` and `contrast` options, `onColorFor` picks a readable on-color
- **`shapes.ts`** — `getShapes` sampling consistency / unit-box normalization / caching, `morphedShape` interpolation and sequence wrapping, `Spring` settling and underdamped overshoot, `LoadingAnimator` rotation bounds and determinism

**Infrastructure:**

- Vitest as a devDependency; `npm test` runs `vitest run`; no config file (default `*.test.ts` discovery)
- Test files import `{ describe, it, expect }` from `"vitest"` — no globals, tsconfig untouched
- Module-level state (language in `i18n.ts`, shape scale in `tokens.ts`) is set explicitly per test and restored in `afterEach`, so results never depend on execution order
- `npm test` added to the existing `check` job in `ci.yml`, after `npm run typecheck`
- CONTRIBUTING.md (setup commands, PR requirements, and the ja / zh summaries) and the PR template checklist now mention `npm test`

51 assertions-first test cases in 6 files, the whole suite finishes in well under a second.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (51/51; verified on both Node 22.22.2 — the CI version — and Node 26)
- [x] `npm run build` passes
- [x] New or changed UI strings and prompt text exist in Japanese, English and Chinese (no UI text changed; docs updated in all three languages)
- [x] Tried it in the editor (test / CI / docs only; no editor behaviour touched)

## Screenshots

No UI changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Vitest unit-test suite for the pure `lib/` modules so regressions in prompt generation, layout tidy, color schemes, and shape animation are caught in CI instead of going silent.

**Test coverage**

- `prompt.ts` gets structural assertions only (no snapshots): heading order in ja/en/zh, platform lines, one style note per part kind, and per-language quote marks.
- `tidy.ts` verifies frame snapping, FAB placement, connected runs, and that already-tidy frames are a no-op.
- `tokens.ts` and `color.ts` cover shape scale, run corners, theme normalization, hex round-trips, and scheme options.
- `shapes.ts` covers sampling, morphing, spring settling, and animator determinism.
- `i18n.ts` checks language validation.

**Infrastructure**

- `npm test` runs `vitest run` and is now part of the CI check job.
- `package.json` declares Node `^22.12.0 || ^24.0.0 || >=26.0.0`; CONTRIBUTING.md documents the 22.12 minimum.
- Module-level state is set per test and restored in `afterEach`, so tests are order-independent.
- CONTRIBUTING.md and the PR template now mention `npm test`.

<sup>Written for commit ade91a35b49f9df781f2c706a72d3e492d5379d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

