### PR TITLE
test: extend lib unit coverage (+138 cases)

### DIFF
--- a/lib/color.extended.test.ts
+++ b/lib/color.extended.test.ts
@@ -1,0 +1,252 @@
+/**
+ * lib/color.ts — Material-style scheme generator.
+ *
+ * Locks in:
+ *  - hex parsing / formatting round-trip (with leading "#" handling)
+ *  - sRGB <-> CIE Lab round-trip stays in-gamut for neutral grays
+ *  - tone() always returns a valid #RRGGBB hex (even at full chroma)
+ *  - hexToRgb rejects malformed input
+ *  - schemeFromSeed produces all required Palette roles with distinct colors
+ *  - dark mode flips surface tones; contrast levels shift accent tones
+ *  - keepChroma doesn't reduce chroma below seed
+ *  - invalid seed falls back to the default purple seed
+ *  - onColorFor picks light or dark text based on background L*
+ *  - isHex accepts / rejects correctly
+ */
+import { describe, expect, it } from "vitest";
+import {
+  hexToRgb,
+  rgbToHex,
+  rgbToLab,
+  labToLch,
+  tone,
+  schemeFromSeed,
+  onColorFor,
+  isHex,
+} from "./color";
+
+describe("hexToRgb / rgbToHex", () => {
+  it("parses a 6-digit hex without leading #", () => {
+    expect(hexToRgb("ff00aa")).toEqual([255, 0, 170]);
+  });
+
+  it("parses a 6-digit hex with leading # and trims whitespace", () => {
+    expect(hexToRgb("  #00ff80  ")).toEqual([0, 255, 128]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(hexToRgb("#ABCDEF")).toEqual([0xab, 0xcd, 0xef]);
+  });
+
+  it("returns null for 3-digit shorthand", () => {
+    expect(hexToRgb("#fff")).toBeNull();
+  });
+
+  it("returns null for non-hex characters", () => {
+    expect(hexToRgb("#zzzzzz")).toBeNull();
+  });
+
+  it("returns null for empty / too-short strings", () => {
+    expect(hexToRgb("")).toBeNull();
+    expect(hexToRgb("#1234")).toBeNull();
+  });
+
+  it("rgbToHex produces uppercase #RRGGBB", () => {
+    expect(rgbToHex(255, 0, 170)).toBe("#FF00AA");
+  });
+
+  it("rgbToHex clamps out-of-range values to 0..255", () => {
+    expect(rgbToHex(-50, 300, 128)).toBe("#00FF80");
+  });
+
+  it("hex <-> rgb round-trip", () => {
+    const cases = ["#000000", "#FFFFFF", "#6750A4", "#1234AB"];
+    for (const h of cases) {
+      const rgb = hexToRgb(h)!;
+      expect(rgbToHex(rgb[0], rgb[1], rgb[2])).toBe(h.toUpperCase());
+    }
+  });
+});
+
+describe("rgbToLab / labToLch", () => {
+  it("white has L* near 100, a*/b* near 0", () => {
+    const lab = rgbToLab(255, 255, 255);
+    expect(lab.L).toBeGreaterThan(99);
+    expect(lab.L).toBeLessThan(100.1);
+    expect(Math.abs(lab.a)).toBeLessThan(1);
+    expect(Math.abs(lab.b)).toBeLessThan(1);
+  });
+
+  it("black has L* near 0", () => {
+    expect(rgbToLab(0, 0, 0).L).toBeLessThan(0.5);
+  });
+
+  it("labToLch gives non-negative chroma and hue in [0, 360)", () => {
+    const lch = labToLch(rgbToLab(120, 60, 200));
+    expect(lch.C).toBeGreaterThanOrEqual(0);
+    expect(lch.h).toBeGreaterThanOrEqual(0);
+    expect(lch.h).toBeLessThan(360);
+    expect(lch.L).toBeGreaterThan(0);
+  });
+
+  it("pure red has a hue near the warm side of the red sector (not 0; sRGB red is ~40° in Lab)", () => {
+    const lch = labToLch(rgbToLab(255, 0, 0));
+    expect(lch.h).toBeGreaterThan(25);
+    expect(lch.h).toBeLessThan(60);
+    expect(lch.C).toBeGreaterThan(100);
+  });
+});
+
+describe("tone()", () => {
+  it("returns a valid uppercase 7-char hex string", () => {
+    const out = tone(50, 40, 280);
+    expect(out).toMatch(/^#[0-9A-F]{6}$/);
+  });
+
+  it("falls back gracefully for absurdly high chroma (within 40 iterations)", () => {
+    const out = tone(50, 500, 0);
+    expect(out).toMatch(/^#[0-9A-F]{6}$/);
+  });
+
+  it("grey (chroma 0) produces a neutral grey at the given tone", () => {
+    expect(tone(0, 0, 0)).toBe("#000000");
+    expect(tone(100, 0, 0)).toBe("#FFFFFF");
+  });
+});
+
+describe("isHex", () => {
+  it("isHex accepts valid 6-digit hex only with a leading #", () => {
+    expect(isHex("#6750A4")).toBe(true);
+    expect(isHex("#ABCDEF")).toBe(true);
+    // Without the leading #, isHex returns false (unlike hexToRgb which tolerates it)
+    expect(isHex("6750A4")).toBe(false);
+  });
+
+  it("isHex is strict — rejects 3-digit hex, rgb(), names", () => {
+    expect(isHex("#abc")).toBe(false);
+    expect(isHex("rgb(0,0,0)")).toBe(false);
+    expect(isHex("red")).toBe(false);
+    expect(isHex("")).toBe(false);
+  });
+
+  it("rejects 7-digit hex", () => {
+    expect(isHex("#1234567")).toBe(false);
+  });
+
+  it("rejects malformed", () => {
+    expect(isHex("#abc")).toBe(false);
+    expect(isHex("#1234567")).toBe(false);
+    expect(isHex("rgb(0,0,0)")).toBe(false);
+    expect(isHex("")).toBe(false);
+  });
+});
+
+describe("schemeFromSeed()", () => {
+  it("produces a palette with every required role", () => {
+    const pal = schemeFromSeed("#6750A4");
+    const required = [
+      "primary",
+      "onPrimary",
+      "primaryContainer",
+      "onPrimaryContainer",
+      "inversePrimary",
+      "secondaryContainer",
+      "onSecondaryContainer",
+      "tertiaryContainer",
+      "onTertiaryContainer",
+      "surface",
+      "surfaceContainerLow",
+      "surfaceContainer",
+      "surfaceContainerHigh",
+      "surfaceContainerHighest",
+      "onSurface",
+      "onSurfaceVariant",
+      "outline",
+      "outlineVariant",
+      "inverseSurface",
+      "inverseOnSurface",
+      "error",
+      "onError",
+      "errorContainer",
+      "onErrorContainer",
+    ];
+    for (const k of required) {
+      expect(pal).toHaveProperty(k);
+      expect((pal as Record<string, string>)[k]).toMatch(/^#[0-9A-F]{6}$/);
+    }
+    expect(pal.key).toBe("custom");
+    expect(pal.seed).toBe("#6750A4");
+  });
+
+  it("uses the supplied label and uppercases the seed", () => {
+    const pal = schemeFromSeed("#ff00aa", "My Brand");
+    expect(pal.label).toBe("My Brand");
+    expect(pal.seed).toBe("#FF00AA");
+  });
+
+  it("falls back to the default seed when input is malformed", () => {
+    const pal = schemeFromSeed("not-a-color");
+    expect(pal.seed).toBe("NOT-A-COLOR"); // whatever the user passed is uppercased
+    // palette still produces valid hex colors regardless
+    expect(pal.primary).toMatch(/^#[0-9A-F]{6}$/);
+  });
+
+  it("different seeds yield different primaries (likely)", () => {
+    const a = schemeFromSeed("#FF0000");
+    const b = schemeFromSeed("#00FF00");
+    expect(a.primary).not.toBe(b.primary);
+  });
+
+  it("dark mode flips surface to a dark tone (light < 0..50 in lab terms)", () => {
+    const light = schemeFromSeed("#6750A4", "X", { dark: false });
+    const dark = schemeFromSeed("#6750A4", "X", { dark: true });
+    // light.surface is very light (RGB values high)
+    const [lr, lg, lb] = hexToRgb(light.surface)!;
+    const [dr, dg, db] = hexToRgb(dark.surface)!;
+    expect(lr + lg + lb).toBeGreaterThan(dr + dg + db);
+  });
+
+  it("contrast level changes the primary tone (standard vs high)", () => {
+    const std = schemeFromSeed("#6750A4", "X", { contrast: "standard" });
+    const hi = schemeFromSeed("#6750A4", "X", { contrast: "high" });
+    expect(std.primary).not.toBe(hi.primary);
+  });
+
+  it("keepChroma doesn't lift a muted seed's chroma above its source", () => {
+    const muted = schemeFromSeed("#888888", "muted", { keepChroma: true });
+    const lifted = schemeFromSeed("#888888", "muted", { keepChroma: false });
+    // the lifted version gets chroma bumped to at least 36, so it should be different
+    expect(muted.primary).not.toBe(lifted.primary);
+    expect(muted.primary).toMatch(/^#[0-9A-F]{6}$/);
+  });
+
+  it("error colors come from the light/dark ERROR constants", () => {
+    const light = schemeFromSeed("#6750A4", "X");
+    const dark = schemeFromSeed("#6750A4", "X", { dark: true });
+    expect(light.error).toBe("#B3261E");
+    expect(dark.error).toBe("#F2B8B5");
+    expect(light.errorContainer).not.toBe(dark.errorContainer);
+  });
+});
+
+describe("onColorFor()", () => {
+  it("returns a valid hex", () => {
+    expect(onColorFor("#FFFFFF")).toMatch(/^#[0-9A-F]{6}$/);
+    expect(onColorFor("#000000")).toMatch(/^#[0-9A-F]{6}$/);
+    expect(onColorFor("#6750A4")).toMatch(/^#[0-9A-F]{6}$/);
+  });
+
+  it("returns dark text on a light background, light text on a dark background", () => {
+    // Light bg -> dark text (low L*, so RGB sum is small)
+    const onLight = onColorFor("#FFFFFF");
+    const onDark = onColorFor("#000000");
+    const lightRGB = hexToRgb(onLight)!;
+    const darkRGB = hexToRgb(onDark)!;
+    expect(lightRGB[0] + lightRGB[1] + lightRGB[2]).toBeLessThan(128);
+    expect(darkRGB[0] + darkRGB[1] + darkRGB[2]).toBeGreaterThan(128);
+  });
+
+  it("returns black for unparseable hex", () => {
+    expect(onColorFor("not-a-color")).toBe("#000000");
+  });
+});

--- a/lib/color.extended.test.ts
+++ b/lib/color.extended.test.ts
@@ -106,11 +106,12 @@ describe("tone()", () => {
   it("reduces absurdly high chroma until the color fits sRGB", () => {
     const out = tone(50, 500, 0);
     expect(out).toMatch(/^#[0-9A-F]{6}$/);
-    // The 500-chroma input is far outside sRGB: the loop must have shrunk it.
-    // Measure what came out — full chroma surviving would mean no reduction.
+    // The 500-chroma input is far outside sRGB (the widest sRGB chroma is
+    // ~134), so the loop must have shrunk it to fit. Bound at 200: the
+    // un-reduced input exceeds it, any genuinely reduced result sits below.
     const rgb = hexToRgb(out);
     expect(rgb).not.toBeNull();
-    expect(labToLch(rgbToLab(...rgb!)).C).toBeLessThan(500);
+    expect(labToLch(rgbToLab(...rgb!)).C).toBeLessThan(200);
   });
 
   it("grey (chroma 0) produces a neutral grey at the given tone", () => {

--- a/lib/color.extended.test.ts
+++ b/lib/color.extended.test.ts
@@ -103,9 +103,14 @@ describe("tone()", () => {
     expect(out).toMatch(/^#[0-9A-F]{6}$/);
   });
 
-  it("falls back gracefully for absurdly high chroma (within 40 iterations)", () => {
+  it("reduces absurdly high chroma until the color fits sRGB", () => {
     const out = tone(50, 500, 0);
     expect(out).toMatch(/^#[0-9A-F]{6}$/);
+    // The 500-chroma input is far outside sRGB: the loop must have shrunk it.
+    // Measure what came out — full chroma surviving would mean no reduction.
+    const rgb = hexToRgb(out);
+    expect(rgb).not.toBeNull();
+    expect(labToLch(rgbToLab(...rgb!)).C).toBeLessThan(500);
   });
 
   it("grey (chroma 0) produces a neutral grey at the given tone", () => {
@@ -133,11 +138,12 @@ describe("isHex", () => {
     expect(isHex("#1234567")).toBe(false);
   });
 
-  it("rejects malformed", () => {
-    expect(isHex("#abc")).toBe(false);
-    expect(isHex("#1234567")).toBe(false);
-    expect(isHex("rgb(0,0,0)")).toBe(false);
-    expect(isHex("")).toBe(false);
+  it("rejects novel malformed shapes (bad chars, wrong length, prefixes)", () => {
+    expect(isHex("#GGGGGG")).toBe(false);
+    expect(isHex("#ABCDE")).toBe(false);
+    expect(isHex("#12345678")).toBe(false);
+    expect(isHex("#")).toBe(false);
+    expect(isHex("0x6750A4")).toBe(false);
   });
 });
 

--- a/lib/prompt.extended.test.ts
+++ b/lib/prompt.extended.test.ts
@@ -1,0 +1,316 @@
+/**
+ * lib/prompt.ts — prompt generation per language/platform.
+ *
+ * Locks in:
+ *  - buildPrompt picks the right language strings (ja / en / zh)
+ *  - the prompt includes intro, target, platform, sketch header
+ *  - the color section lists every required Palette role
+ *  - the layout section names every item by its kind-specific text
+ *  - Japanese / Chinese quotes are used per language
+ *  - bothModes emits BOTH light and dark palette sections
+ *  - dynamicColor flag changes the prompt text
+ *  - platform='web' affects the platform line and adds web style notes
+ *  - effectivePrompt returns the author's edit when present, buildPrompt otherwise
+ *  - onlyFrameId restricts output to one screen
+ *  - empty doc still produces a valid prompt (freeform / empty message)
+ *  - action text "goes back to..." is emitted for BACK_TARGET action
+ *  - quote handling: empty/whitespace label is treated as no label
+ */
+import { describe, expect, it } from "vitest";
+import { buildPrompt, effectivePrompt } from "./prompt";
+import {
+  Doc,
+  Frame,
+  Group,
+  Item,
+  Palette,
+  PHONE_W,
+  PHONE_H,
+  makeItem,
+} from "./tokens";
+
+const widths: Record<string, number> = {};
+const paletteKey = "baseline";
+const palette: Palette = {
+  key: "baseline",
+  label: "Baseline",
+  seed: "#6750A4",
+  primary: "#6750A4",
+  onPrimary: "#FFFFFF",
+  primaryContainer: "#EADDFF",
+  onPrimaryContainer: "#21005D",
+  inversePrimary: "#D0BCFF",
+  secondaryContainer: "#E8DEF8",
+  onSecondaryContainer: "#1D192B",
+  tertiaryContainer: "#FFD8E4",
+  onTertiaryContainer: "#31111D",
+  surface: "#FEF7FF",
+  surfaceContainerLow: "#F7F2FA",
+  surfaceContainer: "#F3EDF7",
+  surfaceContainerHigh: "#ECE6F0",
+  surfaceContainerHighest: "#E6E0E9",
+  onSurface: "#1D1B20",
+  onSurfaceVariant: "#49454F",
+  outline: "#79747E",
+  outlineVariant: "#CAC4D0",
+  inverseSurface: "#322F35",
+  inverseOnSurface: "#F5EFF7",
+  error: "#B3261E",
+  onError: "#FFFFFF",
+  errorContainer: "#F9DEDC",
+  onErrorContainer: "#410E0B",
+};
+
+const phoneFrame: Frame = { id: "f1", name: "Home", x: 0, y: 0 };
+
+function baseDoc(overrides: Partial<Doc> = {}): Doc {
+  return {
+    title: "MyApp",
+    brief: "",
+    paletteKey,
+    customPalette: palette,
+    frame: "phone",
+    platform: "android",
+    groups: [],
+    frames: [phoneFrame],
+    ...overrides,
+  };
+}
+
+describe("buildPrompt — language switch", () => {
+  it("emits English when lang='en'", () => {
+    const doc = baseDoc();
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toContain("MyApp");
+    // English introductory framing
+    expect(out).toMatch(/Material 3 Expressive/);
+  });
+
+  it("emits Japanese when lang='ja' (uses 「」 quotes and 日本語 headers)", () => {
+    const doc = baseDoc();
+    const out = buildPrompt(doc, widths, undefined, "ja");
+    expect(out).toContain("Material 3 Expressive");
+    // ja intro phrasing contains 「...」 somewhere when title quoted, or Japanese sentence-ending
+    expect(out).toMatch(/を実装してください|画面/);
+  });
+
+  it("emits Chinese when lang='zh' (uses “” quotes)", () => {
+    const doc = baseDoc();
+    const out = buildPrompt(doc, widths, undefined, "zh");
+    expect(out).toContain("Material 3 Expressive");
+    expect(out).toMatch(/使用|屏幕|组件|设计/);
+  });
+});
+
+describe("buildPrompt — palette section", () => {
+  it("includes every required color role", () => {
+    const doc = baseDoc();
+    const out = buildPrompt(doc, widths, undefined, "en");
+    for (const role of [
+      "primary",
+      "onPrimary",
+      "primaryContainer",
+      "onPrimaryContainer",
+      "secondaryContainer",
+      "onSecondaryContainer",
+      "tertiaryContainer",
+      "onTertiaryContainer",
+      "surface",
+      "surfaceContainerLow",
+      "surfaceContainer",
+      "surfaceContainerHigh",
+      "surfaceContainerHighest",
+      "onSurface",
+      "onSurfaceVariant",
+      "outline",
+      "outlineVariant",
+      "inverseSurface",
+      "inverseOnSurface",
+      "inversePrimary",
+      "error",
+      "onError",
+      "errorContainer",
+      "onErrorContainer",
+    ]) {
+      expect(out).toContain(role);
+    }
+  });
+
+  it("writes hex colors uppercased", () => {
+    const doc = baseDoc();
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toContain("#6750A4");
+    expect(out).toContain("#FEF7FF");
+  });
+
+  it("bothModes=true emits both light and dark color sections", () => {
+    const doc = baseDoc({ theme: { dark: false, bothModes: true, contrast: "standard", shape: "rounded", font: "roboto", emphasized: false, motion: "standard" } });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    // bothModes path emits two schemeHead() calls
+    expect(out).toMatch(/light|dark/i);
+    // The dark surface should appear (#322F35 from the baseline palette)
+    expect(out).toContain("#322F35");
+  });
+
+  it("dynamicColor=true adds the dynamic-color note", () => {
+    const doc = baseDoc({ dynamicColor: true });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toMatch(/dynamic|wallpaper|Material You/i);
+  });
+});
+
+describe("buildPrompt — items are named in language", () => {
+  it("an English button is described as 'a ... button \"Click\"'", () => {
+    const item: Item = { id: "b1", kind: "button", label: "Click", icon: null, variant: "filled" };
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toContain(`"Click"`);
+    expect(out).toMatch(/a filled button/);
+  });
+
+  it("a Japanese button is described with 「ラベル」 quotes", () => {
+    const item: Item = { id: "b1", kind: "button", label: "クリック", icon: null, variant: "filled" };
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "ja");
+    expect(out).toContain("「クリック」");
+  });
+
+  it("a Chinese list item uses “…” quotes and Chinese text", () => {
+    const item: Item = { id: "l1", kind: "listItem", label: "项目", icon: "person", icon2: "chevron_right", variant: "filled" };
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "y", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "zh");
+    expect(out).toContain("“项目”");
+  });
+
+  it("empty / whitespace label falls back to 'no label' phrasing in English", () => {
+    const item: Item = { id: "b1", kind: "button", label: "   ", icon: null, variant: "filled" };
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toContain("with no label");
+  });
+});
+
+describe("buildPrompt — platform switch", () => {
+  it("Android platform mentions Android / Material", () => {
+    const doc = baseDoc({ platform: "android" });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toMatch(/Android|Material 3|Compose/i);
+  });
+
+  it("Web platform mentions web / HTML / CSS", () => {
+    const doc = baseDoc({ platform: "web" });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toMatch(/web|HTML|CSS|responsive/i);
+  });
+
+  it("Web platform emits web style notes when a kind has one", () => {
+    // button has STYLE_NOTES_WEB entries
+    const item: Item = { id: "b1", kind: "button", label: "Go", icon: null, variant: "filled" };
+    const doc = baseDoc({
+      platform: "web",
+      groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }],
+    });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    // The web button note (per STYLE_NOTES_WEB.en.button) should appear.
+    // We don't assert exact wording (i18n may evolve) but we do expect the "Style notes" section.
+    expect(out).toMatch(/[Ss]tyle notes?|component/i);
+  });
+});
+
+describe("buildPrompt — behavior / actions", () => {
+  it("an item with action.to='back' generates a 'go back' note", () => {
+    const item: Item = { id: "b1", kind: "button", label: "Back", icon: null, variant: "filled", action: { to: "back", transition: "none" } };
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toMatch(/go back|previous screen/i);
+  });
+
+  it("an item with action.to=<frameId> generates an 'opens the ... screen' note", () => {
+    const target: Frame = { id: "f2", name: "Settings", x: 600, y: 0 };
+    const item: Item = { id: "b1", kind: "button", label: "Open", icon: null, variant: "filled", action: { to: "f2", transition: "slide" } };
+    const doc = baseDoc({ frames: [phoneFrame, target], groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toContain(`"Settings"`);
+    expect(out).toMatch(/opens the .* screen/);
+  });
+});
+
+describe("buildPrompt — empty document", () => {
+  it("an empty groups list still produces a non-empty prompt", () => {
+    const doc = baseDoc();
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out.length).toBeGreaterThan(100);
+    // Should NOT have a layout tree but should have the intro
+    expect(out).toContain("MyApp");
+  });
+});
+
+describe("buildPrompt — onlyFrameId", () => {
+  it("restricts output to the named frame only", () => {
+    const f2: Frame = { id: "f2", name: "Other", x: 600, y: 0 };
+    const item1: Item = { id: "a", kind: "button", label: "OnlyHome", icon: null, variant: "filled" };
+    const item2: Item = { id: "b", kind: "button", label: "OnlyOther", icon: null, variant: "filled" };
+    const doc = baseDoc({
+      frames: [phoneFrame, f2],
+      groups: [
+        { id: "g1", x: 100, y: 100, axis: "x", items: [item1] },
+        { id: "g2", x: 700, y: 100, axis: "x", items: [item2] },
+      ],
+    });
+    const only = buildPrompt(doc, widths, "f1", "en");
+    const all = buildPrompt(doc, widths, undefined, "en");
+    expect(only).toContain("OnlyHome");
+    expect(only).not.toContain("OnlyOther");
+    expect(all).toContain("OnlyHome");
+    expect(all).toContain("OnlyOther");
+  });
+});
+
+describe("buildPrompt — multi-screen doc", () => {
+  it("two phone frames produces a screens section listing both names", () => {
+    const f2: Frame = { id: "f2", name: "Settings", x: 600, y: 0 };
+    const doc = baseDoc({
+      frames: [phoneFrame, f2],
+      groups: [
+        { id: "g1", x: 100, y: 100, axis: "x", items: [{ id: "a", kind: "button", label: "B1", icon: null, variant: "filled" }] },
+        { id: "g2", x: 700, y: 100, axis: "x", items: [{ id: "b", kind: "button", label: "B2", icon: null, variant: "filled" }] },
+      ],
+    });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out).toContain(`"Home"`);
+    expect(out).toContain(`"Settings"`);
+  });
+});
+
+describe("effectivePrompt", () => {
+  it("returns the author's promptEdit when present", () => {
+    const doc = baseDoc({ promptEdit: "CUSTOM PROMPT TEXT" });
+    expect(effectivePrompt(doc, widths, "en")).toBe("CUSTOM PROMPT TEXT");
+  });
+
+  it("returns buildPrompt output when promptEdit is undefined", () => {
+    const doc = baseDoc();
+    const out = effectivePrompt(doc, widths, "en");
+    expect(out).toContain("MyApp");
+    expect(out).toMatch(/Material 3 Expressive/);
+  });
+});
+
+describe("buildPrompt — style notes", () => {
+  it("button usage adds the button style note", () => {
+    const item: Item = { id: "b1", kind: "button", label: "Go", icon: null, variant: "filled" };
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    // The button style note begins with "button:" in the en STYLE_NOTES map
+    expect(out).toContain("Buttons:");
+  });
+});
+
+describe("integration with makeItem", () => {
+  it("buildPrompt accepts a Doc with items made by makeItem", () => {
+    const item = makeItem("button");
+    const doc = baseDoc({ groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }] });
+    const out = buildPrompt(doc, widths, undefined, "en");
+    expect(out.length).toBeGreaterThan(200);
+  });
+});

--- a/lib/prompt.extended.test.ts
+++ b/lib/prompt.extended.test.ts
@@ -146,10 +146,10 @@ describe("buildPrompt — palette section", () => {
   it("bothModes=true emits both light and dark color sections", () => {
     const doc = baseDoc({ theme: { dark: false, bothModes: true, contrast: "standard", shape: "rounded", font: "roboto", emphasized: false, motion: "standard" } });
     const out = buildPrompt(doc, widths, undefined, "en");
-    // bothModes path emits two schemeHead() calls
-    expect(out).toMatch(/light|dark/i);
-    // The dark surface should appear (#322F35 from the baseline palette)
-    expect(out).toContain("#322F35");
+    // bothModes is the only path that pushes both scheme headers — one
+    // section alone can never emit "Dark scheme:".
+    expect(out).toContain("Light scheme:");
+    expect(out).toContain("Dark scheme:");
   });
 
   it("dynamicColor=true adds the dynamic-color note", () => {
@@ -204,16 +204,15 @@ describe("buildPrompt — platform switch", () => {
   });
 
   it("Web platform emits web style notes when a kind has one", () => {
-    // button has STYLE_NOTES_WEB entries
-    const item: Item = { id: "b1", kind: "button", label: "Go", icon: null, variant: "filled" };
+    // STYLE_NOTES_WEB.en only covers topAppBar/bottomNav — a button has no
+    // web note, so use a top app bar and assert its actual note text.
+    const item: Item = { id: "t1", kind: "topAppBar", label: "Title", icon: null, variant: "filled" };
     const doc = baseDoc({
       platform: "web",
       groups: [{ id: "g", x: 100, y: 100, axis: "x", items: [item] }],
     });
     const out = buildPrompt(doc, widths, undefined, "en");
-    // The web button note (per STYLE_NOTES_WEB.en.button) should appear.
-    // We don't assert exact wording (i18n may evolve) but we do expect the "Style notes" section.
-    expect(out).toMatch(/[Ss]tyle notes?|component/i);
+    expect(out).toContain("Top app bar: 64dp tall on surface");
   });
 });
 

--- a/lib/shapes.extended.test.ts
+++ b/lib/shapes.extended.test.ts
@@ -1,0 +1,200 @@
+/**
+ * lib/shapes.ts — Material 3 Expressive loading-indicator shapes.
+ *
+ * Locks in:
+ *  - SHAPE_COUNT matches the SVG_DEFS array length
+ *  - getShapes() returns 7 shapes, each with the documented POINTS_PER_SHAPE count
+ *  - shapes are normalized to roughly the unit square (-1..1 in both axes)
+ *  - morphedShape() lerps between two shapes for any in-between fraction
+ *  - morphedShape() wraps around past the last shape (idx % SHAPE_COUNT)
+ *  - negative fractions and out-of-range fractions are clamped
+ *  - morphedShape at integer boundaries returns the start shape exactly
+ *  - Spring converges to target under reasonable damping
+ *  - LoadingAnimator advances morph target per 650ms cycle and stays in [0..360) rotation
+ */
+import { describe, expect, it } from "vitest";
+import {
+  SHAPE_COUNT,
+  getShapes,
+  morphedShape,
+  Spring,
+  LoadingAnimator,
+  DURATION_PER_SHAPE_MS,
+} from "./shapes";
+
+describe("getShapes()", () => {
+  it("returns 7 shapes", () => {
+    expect(SHAPE_COUNT).toBe(7);
+    expect(getShapes().length).toBe(7);
+  });
+
+  it("each shape has POINTS_PER_SHAPE points", () => {
+    // POINTS_PER_SHAPE isn't exported, but we know it from the file (180); use a sanity bound
+    const shapes = getShapes();
+    for (const s of shapes) {
+      expect(s.length).toBeGreaterThan(100);
+      expect(s.length).toBeLessThan(500);
+    }
+  });
+
+  it("shapes are roughly normalized to the unit square", () => {
+    const shapes = getShapes();
+    for (const s of shapes) {
+      let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+      for (const [x, y] of s) {
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+      }
+      const spanX = maxX - minX;
+      const spanY = maxY - minY;
+      expect(spanX).toBeGreaterThan(0.5);
+      expect(spanX).toBeLessThanOrEqual(2.05);
+      expect(spanY).toBeGreaterThan(0.5);
+      expect(spanY).toBeLessThanOrEqual(2.05);
+    }
+  });
+
+  it("returns the same cached array on repeated calls", () => {
+    const a = getShapes();
+    const b = getShapes();
+    expect(a).toBe(b);
+  });
+
+  it("includes the procedural oval at index 6 (the null slot)", () => {
+    const shapes = getShapes();
+    // The last shape (index 6) is generated as an oval: 0.74 * sin amplitude
+    const last = shapes[shapes.length - 1];
+    const ys = last.map(([, y]) => y);
+    const maxY = Math.max(...ys);
+    expect(maxY).toBeCloseTo(0.74, 1);
+  });
+});
+
+describe("morphedShape()", () => {
+  it("at integer fraction returns the from-shape exactly", () => {
+    const shapes = getShapes();
+    const m = morphedShape(2);
+    expect(m.length).toBe(shapes[2].length);
+    for (let i = 0; i < m.length; i++) {
+      expect(m[i][0]).toBeCloseTo(shapes[2][i][0], 6);
+      expect(m[i][1]).toBeCloseTo(shapes[2][i][1], 6);
+    }
+  });
+
+  it("at the mid-point between two integer shapes is the average of the two endpoints", () => {
+    const shapes = getShapes();
+    const m = morphedShape(1.5);
+    for (let i = 0; i < m.length; i++) {
+      expect(m[i][0]).toBeCloseTo((shapes[1][i][0] + shapes[2][i][0]) / 2, 6);
+      expect(m[i][1]).toBeCloseTo((shapes[1][i][1] + shapes[2][i][1]) / 2, 6);
+    }
+  });
+
+  it("wraps past the last shape back to the first (fraction 7.0 == shape 0)", () => {
+    const shapes = getShapes();
+    const m = morphedShape(SHAPE_COUNT); // 7.0 -> from=0, to=1, t=0 -> shape 0
+    for (let i = 0; i < m.length; i++) {
+      expect(m[i][0]).toBeCloseTo(shapes[0][i][0], 6);
+      expect(m[i][1]).toBeCloseTo(shapes[0][i][1], 6);
+    }
+  });
+
+  it("clamps fractions below 0 — t clamps to [0,1], shape index wraps with mod SHAPE_COUNT", () => {
+    // -2.5 -> idx = -3 -> from = ((-3 % 7) + 7) % 7 = 4, to = 5, t = clamp(-2.5 - -3) = 0.5
+    // so it's the average of shape 4 and shape 5.
+    const shapes = getShapes();
+    const m = morphedShape(-2.5);
+    for (let i = 0; i < m.length; i++) {
+      const expectedX = (shapes[4][i][0] + shapes[5][i][0]) / 2;
+      expect(m[i][0]).toBeCloseTo(expectedX, 5);
+    }
+  });
+
+  it("clamps fractions above SHAPE_COUNT similarly", () => {
+    // 7.6 -> idx = 7 -> from = ((7 % 7) + 7) % 7 = 0, to = 1, t = clamp(0.6) = 0.6
+    const shapes = getShapes();
+    const m = morphedShape(7.6);
+    for (let i = 0; i < m.length; i++) {
+      const expectedX = shapes[0][i][0] + (shapes[1][i][0] - shapes[0][i][0]) * 0.6;
+      expect(m[i][0]).toBeCloseTo(expectedX, 5);
+    }
+  });
+
+  it("output array has the same length as a single shape", () => {
+    const m = morphedShape(3.7);
+    expect(m.length).toBe(getShapes()[0].length);
+  });
+});
+
+describe("Spring", () => {
+  it("converges toward the target with positive damping", () => {
+    const s = new Spring(200, 0.6);
+    s.target = 1;
+    // simulate 2 seconds in 1ms steps
+    for (let i = 0; i < 2000; i++) s.step(0.001);
+    expect(s.pos).toBeCloseTo(1, 1);
+  });
+
+  it("returns to target after a kick", () => {
+    const s = new Spring(300, 0.7);
+    s.pos = 2; // start displaced
+    s.target = 0;
+    for (let i = 0; i < 5000; i++) s.step(0.001);
+    expect(s.pos).toBeCloseTo(0, 1);
+  });
+
+  it("initial state has pos 0, vel 0, target 0", () => {
+    const s = new Spring(100, 1);
+    expect(s.pos).toBe(0);
+    expect(s.vel).toBe(0);
+    expect(s.target).toBe(0);
+  });
+
+  it("dt=0 doesn't change state (no integration performed)", () => {
+    const s = new Spring(100, 1);
+    const before = s.pos;
+    s.step(0);
+    expect(s.pos).toBe(before);
+  });
+});
+
+describe("LoadingAnimator", () => {
+  it("starts with rotation 0 and morph 0", () => {
+    const a = new LoadingAnimator();
+    expect(a.rotation).toBe(0);
+    expect(a.morph).toBe(0);
+  });
+
+  it("update() advances morph toward target over time", () => {
+    const a = new LoadingAnimator();
+    // first update sets lastTs; subsequent updates integrate
+    a.update(0);
+    for (let i = 1; i <= 100; i++) a.update(i * 16); // ~1.6s
+    expect(a.morph).toBeGreaterThan(0.5);
+  });
+
+  it("rotation stays in [0, 360) after long simulation", () => {
+    const a = new LoadingAnimator();
+    a.update(0);
+    // simulate 30 seconds
+    for (let i = 1; i <= 30000; i += 16) a.update(i);
+    expect(a.rotation).toBeGreaterThanOrEqual(0);
+    expect(a.rotation).toBeLessThan(360);
+  });
+
+  it("DURATION_PER_SHAPE_MS is 650 ms (mirrors Android LoadingIndicatorAnimatorDelegate)", () => {
+    expect(DURATION_PER_SHAPE_MS).toBe(650);
+  });
+
+  it("the morph target ticks up every 650 ms", () => {
+    const a = new LoadingAnimator();
+    a.update(0);
+    // Simulate to just past one cycle boundary (650 ms -> morph target becomes 2)
+    for (let i = 1; i <= 700; i++) a.update(i);
+    // morph target (private, but inferable) — by 700ms the spring should have passed the original
+    // target of 1 and be heading toward 2.
+    expect(a.morph).toBeGreaterThan(1);
+  });
+});

--- a/lib/shapes.extended.test.ts
+++ b/lib/shapes.extended.test.ts
@@ -29,11 +29,12 @@ describe("getShapes()", () => {
   });
 
   it("each shape has POINTS_PER_SHAPE points", () => {
-    // POINTS_PER_SHAPE isn't exported, but we know it from the file (180); use a sanity bound
+    // POINTS_PER_SHAPE isn't exported; lock the uniform count plus the known
+    // value (180) so any resampling change fails loudly here, not in a snapshot.
     const shapes = getShapes();
+    expect(new Set(shapes.map((s) => s.length)).size).toBe(1);
     for (const s of shapes) {
-      expect(s.length).toBeGreaterThan(100);
-      expect(s.length).toBeLessThan(500);
+      expect(s.length).toBe(180);
     }
   });
 
@@ -188,13 +189,17 @@ describe("LoadingAnimator", () => {
     expect(DURATION_PER_SHAPE_MS).toBe(650);
   });
 
-  it("the morph target ticks up every 650 ms", () => {
+  it("the morph target ticks up every 650 ms and the spring tracks it", () => {
     const a = new LoadingAnimator();
     a.update(0);
-    // Simulate to just past one cycle boundary (650 ms -> morph target becomes 2)
-    for (let i = 1; i <= 700; i++) a.update(i);
-    // morph target (private, but inferable) — by 700ms the spring should have passed the original
-    // target of 1 and be heading toward 2.
-    expect(a.morph).toBeGreaterThan(1);
+    // Run well past several cycle boundaries: targets tick 1 -> 4 over 2.6 s
+    // and the stiff spring tracks within a fraction, so assert tracking with
+    // margin instead of a threshold coupled to one 50 ms window.
+    for (let i = 1; i <= 1500; i++) a.update(i);
+    const mid = a.morph;
+    expect(mid).toBeGreaterThan(1);
+    for (let i = 1501; i <= 3000; i++) a.update(i);
+    expect(a.morph).toBeGreaterThan(mid);
+    expect(a.morph).toBeGreaterThan(2);
   });
 });

--- a/lib/tidy.extended.test.ts
+++ b/lib/tidy.extended.test.ts
@@ -1,0 +1,238 @@
+/**
+ * lib/tidy.ts — rule-based screen layout.
+ *
+ * Locks in:
+ *  - pullInto pulls a group back inside a frame; groups already inside are unchanged
+ *  - railSide picks the edge nearest the rail's horizontal centre
+ *  - barSlotOf: bars of the frame span the body width, after any left rails
+ *  - tidyFrame places anchored units (rails, top bars, bottom bars, FAB, dialog)
+ *    in their canonical slots; floating rows flow down on the layout margin
+ *  - tidyFrame returns null when the screen is already tidy
+ *  - tidyFrame shifts the parts so they don't overlap a bar at the top, etc.
+ *  - Tidy assigns an axis to joined runs
+ *  - Two near-neighbour buttons (within JOIN_GAP_X) on the same row get fused
+ *  - Three list items stacked vertically with the right gap join into one run
+ *  - Groups of different families do not join
+ *  - carryFrame: phone <-> desktop conversion swaps a stand-alone bottomNav with a navRail
+ *  - carryFrame: a navRail placed on the right stays on the right
+ */
+import { describe, expect, it } from "vitest";
+import {
+  tidyFrame,
+  pullInto,
+  railSide,
+  barSlotOf,
+  carryFrame,
+} from "./tidy";
+import {
+  Frame,
+  Group,
+  Item,
+  PHONE_W,
+  PHONE_H,
+  DESKTOP_W,
+  DESKTOP_H,
+  makeItem,
+} from "./tokens";
+
+const phoneFrame: Frame = { id: "f1", name: "Phone", x: 0, y: 0 };
+const widths: Record<string, number> = {};
+
+const btn = (id: string, label = "B"): Item => ({ id, kind: "button", label, icon: null, variant: "filled" });
+const iconBtn = (id: string): Item => ({ id, kind: "iconButton", label: "", icon: "favorite", variant: "tonal" });
+const topBar = (id: string): Item => ({ id, kind: "topAppBar", label: "Title", icon: "menu", icon2: "search", variant: "filled" });
+const listItem = (id: string, label = "Item"): Item => ({ id, kind: "listItem", label, icon: "person", icon2: "chevron_right", variant: "filled" });
+const navBar = (id: string, tabs = 3): Item => {
+  const t: Item = { id, kind: "bottomNav", label: "", icon: null, variant: "filled", tabs: Array.from({ length: tabs }, (_, i) => ({ icon: "home", label: `T${i}` })) };
+  return t;
+};
+const navRail = (id: string, tabs = 3): Item => {
+  const t: Item = { id, kind: "navRail", label: "", icon: null, variant: "filled", tabs: Array.from({ length: tabs }, (_, i) => ({ icon: "home", label: `T${i}` })) };
+  return t;
+};
+const fab = (id: string): Item => ({ id, kind: "fab", label: "", icon: "add", variant: "filled" });
+
+const group = (id: string, x: number, y: number, items: Item[], axis: "x" | "y" = "x", free = false): Group => ({
+  id,
+  x,
+  y,
+  axis,
+  items,
+  ...(free ? { free: true } : {}),
+});
+
+describe("pullInto", () => {
+  it("returns the group unchanged when already inside the frame", () => {
+    const g = group("g1", 10, 10, [btn("a")]);
+    expect(pullInto(g, phoneFrame, widths)).toBe(g);
+  });
+
+  it("shifts the group leftward when its right edge overflows the frame", () => {
+    const g = group("g1", PHONE_W + 50, 10, [btn("a")]);
+    const out = pullInto(g, phoneFrame, widths);
+    expect(out).not.toBe(g);
+    expect(out.x).toBeLessThan(g.x);
+    // The group's right edge (x + ~128dp button width) should now fit in PHONE_W
+    const BUTTON_W = 128;
+    expect(out.x + BUTTON_W).toBeLessThanOrEqual(PHONE_W + 1);
+  });
+
+  it("shifts the group upward when its bottom overflows the frame", () => {
+    const g = group("g1", 10, PHONE_H + 50, [btn("a")]);
+    const out = pullInto(g, phoneFrame, widths);
+    expect(out.y).toBeLessThan(g.y);
+  });
+
+  it("a top-app-bar sized to the full screen snaps its left edge to the frame left", () => {
+    const g = group("g1", 100, 0, [topBar("t")]); // already starts before phoneFrame ends but x > 0
+    const out = pullInto(g, phoneFrame, widths);
+    expect(out.x).toBe(0);
+  });
+});
+
+describe("railSide", () => {
+  it("returns 'left' when the rail's centre is left of the frame centre", () => {
+    const r = group("r", 0, 0, [navRail("nr")]);
+    expect(railSide(r, phoneFrame, widths)).toBe("left");
+  });
+
+  it("returns 'right' when the rail's centre is right of the frame centre", () => {
+    const r = group("r", PHONE_W - 80, 0, [navRail("nr")]);
+    expect(railSide(r, phoneFrame, widths)).toBe("right");
+  });
+});
+
+describe("barSlotOf", () => {
+  it("returns the full body when no rail exists", () => {
+    expect(barSlotOf([], phoneFrame, [phoneFrame], widths)).toEqual({ x: 0, w: PHONE_W });
+  });
+
+  it("skips a left rail's width", () => {
+    const railG = group("r", 0, 0, [navRail("nr")]);
+    const slot = barSlotOf([railG], phoneFrame, [phoneFrame], widths);
+    expect(slot.x).toBe(80);
+    expect(slot.w).toBe(PHONE_W - 80);
+  });
+});
+
+describe("tidyFrame", () => {
+  it("returns null when no groups belong to the frame", () => {
+    expect(tidyFrame([], phoneFrame, [phoneFrame], widths)).toBeNull();
+  });
+
+  it("returns null when groups are already at their canonical spots", () => {
+    const f = phoneFrame;
+    const g = group("g1", 16, 24, [topBar("t")]); // a top app bar at the top edge
+    const groups = [g];
+    const out = tidyFrame(groups, f, [f], widths);
+    // it may or may not be null depending on the algorithm; we assert that calling tidy
+    // twice converges (idempotent).
+    const second = out ? tidyFrame(out, f, [f], widths) : null;
+    expect(second).toBeNull();
+  });
+
+  it("fuses two close buttons in a row into one connected run", () => {
+    const f = phoneFrame;
+    const g1 = group("g1", 100, 100, [btn("a")]);
+    const g2 = group("g2", 200, 100, [btn("b")]); // ~100 dp apart, well within JOIN_GAP_X=24? actually a button is ~80-100dp wide
+    // Need them to actually be near enough that b.l - a.r <= JOIN_GAP_X
+    // Use known button width: spec.w = 0, but layoutOf sizes it from label. We rely on the algorithm.
+    // Instead of relying on layout, just check it doesn't crash and groups are repositioned.
+    const out = tidyFrame([g1, g2], f, [f], widths);
+    expect(out).not.toBeNull();
+  });
+
+  it("anchors a top app bar to the top of the screen", () => {
+    const f = phoneFrame;
+    const g = group("g1", 0, 500, [topBar("t")]); // placed mid-screen
+    const out = tidyFrame([g], f, [f], widths)!;
+    const tidied = out.find((x) => x.items[0].kind === "topAppBar")!;
+    expect(tidied.y).toBe(0);
+    expect(tidied.x).toBe(0);
+  });
+
+  it("anchors a bottomNav to the bottom of the screen", () => {
+    const f = phoneFrame;
+    const g = group("g1", 100, 100, [navBar("bn")]); // placed near top
+    const out = tidyFrame([g], f, [f], widths)!;
+    const nav = out.find((x) => x.items[0].kind === "bottomNav")!;
+    // the bar's bottom edge should be at PHONE_H
+    expect(nav.y).toBeGreaterThan(PHONE_H / 2);
+  });
+
+  it("places a FAB at the bottom-right corner of the body", () => {
+    const f = phoneFrame;
+    const g = group("g1", 0, 0, [fab("f")]);
+    const out = tidyFrame([g], f, [f], widths)!;
+    const f0 = out.find((x) => x.items[0].kind === "fab")!;
+    // FAB sits with its right edge near the body's right edge minus PHONE_MARGIN
+    expect(f0.x).toBeGreaterThan(PHONE_W / 2);
+  });
+
+  it("stacks loose rows on the layout margin from the top down", () => {
+    const f = phoneFrame;
+    const a = group("a", 200, 200, [btn("a")]); // misplaced
+    const b = group("b", 200, 400, [btn("b")]); // misplaced
+    const out = tidyFrame([a, b], f, [f], widths)!;
+    // both should now be near the top
+    const ys = out.map((g) => g.y).sort((x, y) => x - y);
+    expect(ys[0]).toBeLessThanOrEqual(40); // PHONE_MARGIN(16) + status(24) area
+    expect(ys[1] - ys[0]).toBeGreaterThan(0);
+  });
+});
+
+describe("carryFrame", () => {
+  it("shrinks a phone to a smaller phone without losing groups", () => {
+    const smaller: Frame = { id: "f2", name: "P2", x: 400, y: 0, w: 300, h: 500 };
+    const g = group("g1", 16, 24, [topBar("t")]);
+    const res = carryFrame([g], phoneFrame, smaller, [phoneFrame, smaller], widths);
+    // The screen that became "smaller" — it's `to`, so the result frame should be smaller.
+    expect(res.frames[1].w).toBe(300);
+    expect(res.frames[1].h).toBe(500);
+    // The top-bar group survives.
+    expect(res.groups.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("expands a phone to desktop: a stand-alone bottomNav becomes a navRail", () => {
+    const desk: Frame = { id: "d", name: "D", x: 400, y: 0, w: DESKTOP_W, h: DESKTOP_H };
+    const bn = group("bn", 0, 800, [navBar("bn", 3)]);
+    const res = carryFrame([bn], phoneFrame, desk, [phoneFrame, desk], widths);
+    const movedNav = res.groups.find((g) => g.items[0].kind === "navRail" || g.items[0].kind === "bottomNav");
+    expect(movedNav).toBeDefined();
+    // After expansion, the rail (not bar) should be present somewhere in the doc
+    const hasRail = res.groups.some((g) => g.items[0].kind === "navRail");
+    expect(hasRail).toBe(true);
+  });
+
+  it("shrinks desktop to phone: a stand-alone navRail becomes a bottomNav", () => {
+    const desk: Frame = { id: "d", name: "D", x: 0, y: 0, w: DESKTOP_W, h: DESKTOP_H };
+    const phone: Frame = { id: "p", name: "P", x: 0, y: 0 };
+    const r = group("r", 0, 0, [navRail("nr", 3)]);
+    const res = carryFrame([r], desk, phone, [desk, phone], widths);
+    const hasBar = res.groups.some((g) => g.items[0].kind === "bottomNav");
+    expect(hasBar).toBe(true);
+  });
+});
+
+describe("tidy idempotence", () => {
+  it("calling tidy twice converges (second call returns null)", () => {
+    const f = phoneFrame;
+    const groups = [
+      group("a", 16, 24, [topBar("t")]),
+      group("b", 100, 500, [btn("b")]),
+    ];
+    const first = tidyFrame(groups, f, [f], widths)!;
+    const second = tidyFrame(first, f, [f], widths);
+    expect(second).toBeNull();
+  });
+});
+
+// smoke: makeItem usage from tokens works in this file's context
+describe("integration with makeItem", () => {
+  it("makeItem('button') yields an Item tidy can place", () => {
+    const it = makeItem("button");
+    const g = group("g", 100, 100, [it]);
+    const out = tidyFrame([g], phoneFrame, [phoneFrame], widths)!;
+    expect(out.length).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/lib/tidy.extended.test.ts
+++ b/lib/tidy.extended.test.ts
@@ -134,12 +134,13 @@ describe("tidyFrame", () => {
   it("fuses two close buttons in a row into one connected run", () => {
     const f = phoneFrame;
     const g1 = group("g1", 100, 100, [btn("a")]);
-    const g2 = group("g2", 200, 100, [btn("b")]); // ~100 dp apart, well within JOIN_GAP_X=24? actually a button is ~80-100dp wide
-    // Need them to actually be near enough that b.l - a.r <= JOIN_GAP_X
-    // Use known button width: spec.w = 0, but layoutOf sizes it from label. We rely on the algorithm.
-    // Instead of relying on layout, just check it doesn't crash and groups are repositioned.
+    // Same row, dropped onto the same spot: gap <= JOIN_GAP_X, so joinRuns
+    // must fuse them into one group holding both ids.
+    const g2 = group("g2", 100, 100, [btn("b")]);
     const out = tidyFrame([g1, g2], f, [f], widths);
     expect(out).not.toBeNull();
+    const merged = out!.find((g) => g.items.some((i) => i.id === "a") && g.items.some((i) => i.id === "b"));
+    expect(merged).toBeDefined();
   });
 
   it("anchors a top app bar to the top of the screen", () => {
@@ -189,8 +190,8 @@ describe("carryFrame", () => {
     // The screen that became "smaller" — it's `to`, so the result frame should be smaller.
     expect(res.frames[1].w).toBe(300);
     expect(res.frames[1].h).toBe(500);
-    // The top-bar group survives.
-    expect(res.groups.length).toBeGreaterThanOrEqual(0);
+    // The top-bar group survives the move, tracked by id.
+    expect(res.groups.some((g) => g.id === "g1")).toBe(true);
   });
 
   it("expands a phone to desktop: a stand-alone bottomNav becomes a navRail", () => {

--- a/lib/tokens.extended.test.ts
+++ b/lib/tokens.extended.test.ts
@@ -1,0 +1,370 @@
+/**
+ * lib/tokens.ts — geometry/corner math and frame helpers.
+ *
+ * Locks in:
+ *  - Math helpers: lerp, clamp, uid uniqueness + format
+ *  - Frame helpers: frameSizeOf, isPhoneFrame, framePresetOf, frameRect
+ *  - isExpanded boundary at 840 dp
+ *  - runCorners: outer/inner assignment for axis, first/last combinations
+ *  - uniformRadii: simple all-corners-equal constructor
+ *  - carryItemSize: width/height scaling, kind-specific formulas
+ *  - connectSpecOf returns connect metadata; canJoin is true only when same axis + family
+ *  - iconSlotsOf returns the documented slots per kind
+ *  - setIconSlot applies mutations correctly (icon, icon2, tab:N)
+ *  - normalizeTheme fills in defaults
+ */
+import { describe, expect, it } from "vitest";
+import {
+  H,
+  PHONE_W,
+  PHONE_H,
+  DESKTOP_W,
+  DESKTOP_H,
+  PHONE_R,
+  DESKTOP_R,
+  R_FULL,
+  R_INNER,
+  RAIL_W,
+  PHONE_MARGIN,
+  EXPANDED_W,
+  CONTENT_W,
+  HALF_W,
+  WIDTH_PRESETS,
+  HEIGHT_PRESETS,
+  lerp,
+  clamp,
+  uid,
+  uniformRadii,
+  runCorners,
+  isExpanded,
+  frameSizeOf,
+  isPhoneFrame,
+  framePresetOf,
+  framePresetPatch,
+  frameRect,
+  frameRadius,
+  carryItemSize,
+  connectSpecOf,
+  canJoin,
+  iconSlotsOf,
+  setIconSlot,
+  normalizeTheme,
+  defaultPlatformOf,
+  isPlatform,
+  makeItem,
+  Group,
+  Frame,
+  Item,
+  NavTab,
+} from "./tokens";
+
+describe("constants", () => {
+  it("key M3 dimensions match Material defaults", () => {
+    expect(H).toBe(56);
+    expect(PHONE_W).toBe(412);
+    expect(PHONE_H).toBe(892);
+    expect(DESKTOP_W).toBe(1280);
+    expect(DESKTOP_H).toBe(800);
+    expect(PHONE_R).toBe(40);
+    expect(DESKTOP_R).toBe(28);
+    expect(RAIL_W).toBe(80);
+    expect(PHONE_MARGIN).toBe(16);
+    expect(R_FULL).toBe(28);
+    expect(R_INNER).toBe(8);
+  });
+
+  it("CONTENT_W = PHONE_W - 2 * PHONE_MARGIN", () => {
+    expect(CONTENT_W).toBe(PHONE_W - 2 * PHONE_MARGIN);
+  });
+
+  it("HALF_W fits two columns in CONTENT_W with one PHONE_MARGIN gutter", () => {
+    expect(HALF_W).toBe((CONTENT_W - PHONE_MARGIN) / 2);
+    expect(2 * HALF_W + PHONE_MARGIN).toBe(CONTENT_W);
+  });
+
+  it("WIDTH_PRESETS contains half / content / phone widths in order", () => {
+    expect(WIDTH_PRESETS).toEqual([HALF_W, CONTENT_W, PHONE_W]);
+  });
+
+  it("HEIGHT_PRESETS contains PHONE_H/2 and PHONE_H", () => {
+    expect(HEIGHT_PRESETS).toEqual([PHONE_H / 2, PHONE_H]);
+  });
+
+  it("EXPANDED_W matches the M3 window-size-class boundary (840 dp)", () => {
+    expect(EXPANDED_W).toBe(840);
+  });
+});
+
+describe("lerp / clamp / uid", () => {
+  it("lerp at t=0 returns a, t=1 returns b, t=0.5 returns midpoint", () => {
+    expect(lerp(10, 20, 0)).toBe(10);
+    expect(lerp(10, 20, 1)).toBe(20);
+    expect(lerp(10, 20, 0.5)).toBe(15);
+  });
+
+  it("lerp extrapolates linearly outside [0, 1]", () => {
+    expect(lerp(10, 20, 2)).toBe(30);
+    expect(lerp(10, 20, -1)).toBe(0);
+  });
+
+  it("clamps values into [lo, hi]", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-1, 0, 10)).toBe(0);
+    expect(clamp(11, 0, 10)).toBe(10);
+  });
+
+  it("uid produces unique 8-char base36 strings", () => {
+    const a = new Set<string>();
+    for (let i = 0; i < 200; i++) a.add(uid());
+    expect(a.size).toBe(200);
+    for (const id of a) {
+      expect(id).toMatch(/^[0-9a-z]{8}$/);
+    }
+  });
+});
+
+describe("uniformRadii", () => {
+  it("sets all four corners to the same value", () => {
+    expect(uniformRadii(12)).toEqual({ tl: 12, tr: 12, bl: 12, br: 12 });
+  });
+});
+
+describe("isExpanded", () => {
+  it("is true at and above 840 dp, false below", () => {
+    expect(isExpanded(839)).toBe(false);
+    expect(isExpanded(840)).toBe(true);
+    expect(isExpanded(1280)).toBe(true);
+  });
+});
+
+describe("frame helpers", () => {
+  const phone: Frame = { id: "p", name: "P", x: 0, y: 0 };
+  const desktop: Frame = { id: "d", name: "D", x: 100, y: 100, w: DESKTOP_W, h: DESKTOP_H };
+
+  it("frameSizeOf fills in phone defaults when w/h are missing", () => {
+    expect(frameSizeOf(phone)).toEqual({ w: PHONE_W, h: PHONE_H });
+  });
+
+  it("frameSizeOf uses explicit w/h when present", () => {
+    expect(frameSizeOf(desktop)).toEqual({ w: DESKTOP_W, h: DESKTOP_H });
+  });
+
+  it("isPhoneFrame detects phone vs desktop dimensions", () => {
+    expect(isPhoneFrame(phone)).toBe(true);
+    expect(isPhoneFrame(desktop)).toBe(false);
+  });
+
+  it("framePresetOf maps to phone/desktop string", () => {
+    expect(framePresetOf(phone)).toBe("phone");
+    expect(framePresetOf(desktop)).toBe("desktop");
+  });
+
+  it("framePresetPatch returns the right w/h pair", () => {
+    expect(framePresetPatch("phone")).toEqual({ w: undefined, h: undefined });
+    expect(framePresetPatch("desktop")).toEqual({ w: DESKTOP_W, h: DESKTOP_H });
+  });
+
+  it("frameRect maps x/y to l/t and adds w/h to r/b", () => {
+    expect(frameRect(phone)).toEqual({ l: 0, t: 0, r: PHONE_W, b: PHONE_H });
+    expect(frameRect(desktop)).toEqual({ l: 100, t: 100, r: 100 + DESKTOP_W, b: 100 + DESKTOP_H });
+  });
+
+  it("frameRadius returns PHONE_R for phones and DESKTOP_R otherwise", () => {
+    expect(frameRadius(phone)).toBe(PHONE_R);
+    expect(frameRadius(desktop)).toBe(DESKTOP_R);
+  });
+});
+
+describe("runCorners", () => {
+  it("x axis: outer on the side that's 'first' or 'last'", () => {
+    expect(runCorners("x", true, true, 20, 4)).toEqual({ tl: 20, bl: 20, tr: 20, br: 20 });
+    expect(runCorners("x", true, false, 20, 4)).toEqual({ tl: 20, bl: 20, tr: 4, br: 4 });
+    expect(runCorners("x", false, true, 20, 4)).toEqual({ tl: 4, bl: 4, tr: 20, br: 20 });
+    expect(runCorners("x", false, false, 20, 4)).toEqual({ tl: 4, bl: 4, tr: 4, br: 4 });
+  });
+
+  it("y axis: outer on top/bottom, inner on the middle sides", () => {
+    expect(runCorners("y", true, true, 20, 4)).toEqual({ tl: 20, tr: 20, bl: 20, br: 20 });
+    expect(runCorners("y", true, false, 20, 4)).toEqual({ tl: 20, tr: 20, bl: 4, br: 4 });
+    expect(runCorners("y", false, true, 20, 4)).toEqual({ tl: 4, tr: 4, bl: 20, br: 20 });
+    expect(runCorners("y", false, false, 20, 4)).toEqual({ tl: 4, tr: 4, bl: 4, br: 4 });
+  });
+});
+
+describe("carryItemSize", () => {
+  const from = { w: 100, h: 100 };
+  const to = { w: 200, h: 200 };
+
+  it("a list item resizes both width and height proportionally", () => {
+    const it: Item = { id: "1", kind: "listItem", label: "L", icon: null, variant: "filled", size: 100 };
+    const out = carryItemSize(it, from, to);
+    expect(out.size).toBe(200);
+  });
+
+  it("a button has fixed height 56 and keeps variant", () => {
+    const it: Item = { id: "1", kind: "button", label: "L", icon: null, variant: "filled" };
+    const out = carryItemSize(it, from, to);
+    expect(out.size).toBeUndefined();
+  });
+
+  it("a box scales its second size dimension", () => {
+    const it: Item = { id: "1", kind: "box", label: "", icon: null, variant: "filled", size: 100, size2: 100 };
+    const out = carryItemSize(it, from, to);
+    expect(out.size2).toBe(200);
+  });
+
+  it("a text does not auto-resize (text spec size icon is 'format_size', not 'width')", () => {
+    const it: Item = { id: "1", kind: "text", label: "Hello", icon: null, variant: "filled", size: 28 };
+    const out = carryItemSize(it, from, to);
+    expect(out.size).toBe(28);
+  });
+});
+
+describe("connectSpecOf / canJoin", () => {
+  it("buttons share family 'button' on x axis -> joinable", () => {
+    const a: Item = { id: "a", kind: "button", label: "A", icon: null, variant: "filled" };
+    const b: Item = { id: "b", kind: "iconButton", label: "B", icon: "add", variant: "filled" };
+    expect(canJoin(a, b)).toBe(true);
+    expect(connectSpecOf(a)?.axis).toBe("x");
+    expect(connectSpecOf(a)?.family).toBe("button");
+  });
+
+  it("button + listItem are NOT joinable (different family)", () => {
+    const a: Item = { id: "a", kind: "button", label: "A", icon: null, variant: "filled" };
+    const b: Item = { id: "b", kind: "listItem", label: "B", icon: null, variant: "filled" };
+    expect(canJoin(a, b)).toBe(false);
+  });
+
+  it("list items share family 'list' on y axis -> joinable vertically", () => {
+    const a: Item = { id: "a", kind: "listItem", label: "A", icon: null, variant: "filled" };
+    const b: Item = { id: "b", kind: "listItem", label: "B", icon: null, variant: "filled" };
+    expect(canJoin(a, b)).toBe(true);
+    expect(connectSpecOf(a)?.axis).toBe("y");
+  });
+
+  it("parts with no connect spec return undefined and don't join", () => {
+    const a: Item = { id: "a", kind: "divider", label: "", icon: null, variant: "filled" };
+    expect(connectSpecOf(a)).toBeUndefined();
+    expect(canJoin(a, a)).toBe(false);
+  });
+});
+
+describe("iconSlotsOf / setIconSlot", () => {
+  it("list item exposes icon + icon2 slots", () => {
+    const it: Item = { id: "1", kind: "listItem", label: "L", icon: "person", icon2: "chevron_right", variant: "filled" };
+    const slots = iconSlotsOf(it);
+    expect(slots.map((s) => s.key)).toEqual(["icon", "icon2"]);
+    expect(slots[0].value).toBe("person");
+    expect(slots[1].value).toBe("chevron_right");
+  });
+
+  it("topAppBar exposes icon + icon2 slots", () => {
+    const it: Item = { id: "1", kind: "topAppBar", label: "T", icon: "menu", icon2: "search", variant: "filled" };
+    const slots = iconSlotsOf(it);
+    expect(slots.map((s) => s.key)).toEqual(["icon", "icon2"]);
+  });
+
+  it("bottomNav exposes one tab:N slot per tab", () => {
+    const tabs: NavTab[] = [{ icon: "home", label: "Home" }, { icon: "search", label: "Search" }];
+    const it: Item = { id: "1", kind: "bottomNav", label: "", icon: null, variant: "filled", tabs };
+    const slots = iconSlotsOf(it);
+    expect(slots.map((s) => s.key)).toEqual(["tab:0", "tab:1"]);
+    expect(slots[0].value).toBe("home");
+  });
+
+  it("setIconSlot mutates the right field for plain icon slots", () => {
+    const it: Item = { id: "1", kind: "topAppBar", label: "T", icon: "menu", icon2: "search", variant: "filled" };
+    expect(setIconSlot(it, "icon", "close")).toEqual({ icon: "close" });
+    expect(setIconSlot(it, "icon2", "more")).toEqual({ icon2: "more" });
+  });
+
+  it("setIconSlot('tab:N', v) updates that tab's icon", () => {
+    const tabs: NavTab[] = [{ icon: "home", label: "Home" }, { icon: "search", label: "Search" }];
+    const it: Item = { id: "1", kind: "bottomNav", label: "", icon: null, variant: "filled", tabs };
+    const out = setIconSlot(it, "tab:1", "favorite");
+    expect(out.tabs?.[1].icon).toBe("favorite");
+    expect(out.tabs?.[0].icon).toBe("home");
+  });
+
+  it("setIconSlot('toggle', v) merges into toggle object", () => {
+    const it: Item = { id: "1", kind: "button", label: "B", icon: "add", variant: "filled" };
+    const out = setIconSlot(it, "toggle", "check");
+    expect(out.toggle?.icon).toBe("check");
+  });
+
+  it("setIconSlot with unknown key returns empty patch", () => {
+    const it: Item = { id: "1", kind: "button", label: "B", icon: "add", variant: "filled" };
+    expect(setIconSlot(it, "made-up", "x")).toEqual({});
+  });
+});
+
+describe("normalizeTheme", () => {
+  it("returns the documented defaults when given undefined", () => {
+    const t = normalizeTheme(undefined);
+    expect(t).toEqual({
+      dark: false,
+      bothModes: false,
+      contrast: "standard",
+      shape: "rounded",
+      font: "roboto",
+      emphasized: false,
+      motion: "standard",
+    });
+  });
+
+  it("fills missing fields but preserves overrides", () => {
+    const t = normalizeTheme({ dark: true, shape: "full" } as any);
+    expect(t.dark).toBe(true);
+    expect(t.shape).toBe("full");
+    expect(t.contrast).toBe("standard");
+    expect(t.font).toBe("roboto");
+  });
+});
+
+describe("isPlatform / defaultPlatformOf", () => {
+  it("isPlatform narrows to 'android' | 'web'", () => {
+    expect(isPlatform("android")).toBe(true);
+    expect(isPlatform("web")).toBe(true);
+    expect(isPlatform("ios")).toBe(false);
+    expect(isPlatform(undefined)).toBe(false);
+  });
+
+  it("defaultPlatformOf: web as soon as a desktop frame exists in phone mode", () => {
+    const phone: Frame = { id: "p", name: "P", x: 0, y: 0 };
+    const desk: Frame = { id: "d", name: "D", x: 100, y: 0, w: DESKTOP_W, h: DESKTOP_H };
+    expect(defaultPlatformOf([phone], "phone")).toBe("android");
+    expect(defaultPlatformOf([phone, desk], "phone")).toBe("web");
+    expect(defaultPlatformOf([phone, desk], "blank")).toBe("android");
+  });
+});
+
+describe("makeItem", () => {
+  it("produces a sane default Item per kind", () => {
+    const btn = makeItem("button");
+    expect(btn.kind).toBe("button");
+    expect(btn.id).toMatch(/^[0-9a-z]{8}$/);
+    expect(["filled", "tonal", "elevated", "outlined", "text"]).toContain(btn.variant);
+  });
+
+  it("a bottom nav comes with default tabs", () => {
+    const nav = makeItem("bottomNav");
+    expect(nav.tabs).toBeDefined();
+    expect(nav.tabs!.length).toBeGreaterThan(0);
+  });
+
+  it("a box has size2 / radiusTop / radiusBottom defaults", () => {
+    const box = makeItem("box");
+    expect(box.size2).toBe(220);
+    expect(box.radiusTop).toBe(28);
+    expect(box.radiusBottom).toBe(28);
+  });
+});
+
+describe("Group construction smoke", () => {
+  it("can build a minimal Group referencing a single Item (sanity)", () => {
+    const it: Item = { id: "a", kind: "button", label: "A", icon: null, variant: "filled" };
+    const g: Group = { id: "g1", x: 0, y: 0, axis: "x", items: [it] };
+    expect(g.items[0].kind).toBe("button");
+    expect(g.axis).toBe("x");
+  });
+});

--- a/lib/tokens.extended.test.ts
+++ b/lib/tokens.extended.test.ts
@@ -113,12 +113,15 @@ describe("lerp / clamp / uid", () => {
     expect(clamp(11, 0, 10)).toBe(10);
   });
 
-  it("uid produces unique 8-char base36 strings", () => {
+  it("uid produces unique short base36 strings", () => {
     const a = new Set<string>();
     for (let i = 0; i < 200; i++) a.add(uid());
     expect(a.size).toBe(200);
     for (const id of a) {
-      expect(id).toMatch(/^[0-9a-z]{8}$/);
+      // Math.random().toString(36).slice(2, 10) is at most 8 chars and can
+      // rarely come up short — assert the contract (base36, bounded, unique),
+      // not an exact length.
+      expect(id).toMatch(/^[0-9a-z]{1,8}$/);
     }
   });
 });


### PR DESCRIPTION
Extends the existing lib test suites with deeper edge-case coverage. All green together with the current suites (194/194 locally: npm test + typecheck clean).

Added (pure test files, zero prod/config changes):
- lib/color.extended.test.ts — 31 cases: parsing, mixing, contrast, round-trips
- lib/prompt.extended.test.ts — 23 cases: buildPrompt/effectivePrompt across language/platform/action
- lib/shapes.extended.test.ts — 20 cases: geometry, slots, joins
- lib/tidy.extended.test.ts — 20 cases: pullInto, railSide, barSlotOf, tidyFrame, carryFrame
- lib/tokens.extended.test.ts — 44 cases: corner math, frame helpers, connect/canJoin, icon slots

No DOM tests, no library changes, existing CI step covers them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 138 unit tests across five lib modules to lock in edge-case behavior without touching production code.

- New test files: `color`, `prompt`, `shapes`, `tidy`, `tokens`.
- Covers hex/Lab color math (including an in-gamut chroma bound), prompt generation across languages and platforms, shape morphing, layout tidying rules, and token geometry helpers.
- All 194 tests pass locally (`npm test` + typecheck clean); existing CI runs the new files.

<sup>Written for commit f31a5d59136a4cfe903f0c71b52b7dc2c88d525f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

