### PR TITLE
test: cover project, share and i18n parity (+236 cases)

### DIFF
--- a/lib/i18n.parity.test.ts
+++ b/lib/i18n.parity.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+import {
+  COLOR_TOKEN_TEXT, FAB_MENU_TABS, KIND_TEXT, LANGS, NAV_TABS, SEED_TEXT,
+  SWIPE_TEXT, TAB_LABELS, TRANSITION_TEXT, t, type UIKey,
+} from "./i18n";
+import { KIND_ORDER, LANG_FONT, SWIPE_DIRS, TRANSITIONS } from "./tokens";
+
+// UI and KO are private. Read only their literal initializers so new UI keys are
+// discovered automatically, without widening the production API or copying keys.
+// These anchors intentionally fail loudly if the dictionary representation changes.
+const source = readFileSync(new URL("./i18n.ts", import.meta.url), "utf8");
+function dictionary(pattern: RegExp): Record<string, unknown> {
+  const literal = source.match(pattern)?.[1];
+  if (!literal) throw new Error(`Could not locate dictionary: ${pattern}`);
+  return runInNewContext(`(${literal})`, Object.create(null), { timeout: 1000 });
+}
+const ui = dictionary(/const UI = (\{[\s\S]*?\n\}) as const/) as Record<UIKey, Record<string, string>>;
+const ko = dictionary(/const KO: Record<UIKey, string> = (\{[\s\S]*?\n\});/);
+const keys = Object.keys(ui) as UIKey[];
+const languages = LANGS.map(({ key }) => key);
+const sortedKeys = (value: object) => Object.keys(value).sort();
+
+function nonemptyStrings(value: unknown, path: string): void {
+  if (value !== null && typeof value === "object") {
+    expect(Object.keys(value).length, path).toBeGreaterThan(0);
+    for (const [key, child] of Object.entries(value)) nonemptyStrings(child, `${path}.${key}`);
+  } else {
+    expect(typeof value, path).toBe("string");
+    expect((value as string).trim(), path).not.toBe("");
+  }
+}
+
+// Include nested optional fields and array indices: losing one translated label
+// or supporting sentence must fail even when the outer kind keys still match.
+function leafPaths(value: unknown, prefix = ""): string[] {
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value).flatMap(([key, child]) => leafPaths(child, `${prefix}.${key}`)).sort();
+  }
+  return [prefix];
+}
+
+describe("UI dictionary parity", () => {
+  it("offers each supported language exactly once with a nonblank display label", () => {
+    expect([...languages].sort()).toEqual(["en", "ja", "ko", "zh"]);
+    for (const { key, label } of LANGS) nonemptyStrings(label, `LANGS.${key}`);
+  });
+
+  it("gives Korean exactly the same keys as the main UI dictionary", () => {
+    expect(keys.length).toBeGreaterThan(0);
+    expect(sortedKeys(ko)).toEqual([...keys].sort());
+  });
+
+  it("gives every main UI key all and only the non-Korean languages", () => {
+    const expected = languages.filter((lang) => lang !== "ko").sort();
+    for (const key of keys) expect(sortedKeys(ui[key]), key).toEqual(expected);
+  });
+
+  it.each(LANGS)("returns a nonblank translation for every UI key in $key", ({ key: lang }) => {
+    for (const key of keys) {
+      const stored = lang === "ko" ? ko[key] : ui[key][lang];
+      nonemptyStrings(stored, `UI.${key}.${lang}`);
+      expect(t(key, lang), `${key}.${lang}`).toBe(stored);
+    }
+  });
+
+  it("keeps template placeholders consistent across languages", () => {
+    const placeholders = (text: string) => [...text.matchAll(/\{([a-zA-Z]\w*)\}/g)].map((match) => match[1]).sort();
+    for (const key of keys) {
+      for (const lang of languages) expect(placeholders(t(key, lang)), `${key}.${lang}`).toEqual(placeholders(t(key, "en")));
+    }
+  });
+});
+
+const dictionaries = { KIND_TEXT, SEED_TEXT, TAB_LABELS, FAB_MENU_TABS, NAV_TABS, TRANSITION_TEXT, SWIPE_TEXT };
+for (const [name, table] of Object.entries(dictionaries)) {
+  describe(`${name} parity`, () => {
+    it("covers exactly the offered languages", () => {
+      expect(sortedKeys(table)).toEqual([...languages].sort());
+    });
+
+    it.each(LANGS)("has the same nested keys and nonblank strings in $key", ({ key: lang }) => {
+      expect(leafPaths(table[lang]), `${name}.${lang}`).toEqual(leafPaths(table.en));
+      nonemptyStrings(table[lang], `${name}.${lang}`);
+    });
+  });
+}
+
+describe("dictionary coverage of editor tokens", () => {
+  it.each(LANGS)("covers every kind, transition and swipe in $key", ({ key: lang }) => {
+    expect(sortedKeys(KIND_TEXT[lang])).toEqual([...KIND_ORDER].sort());
+    expect(sortedKeys(TRANSITION_TEXT[lang])).toEqual(TRANSITIONS.map(({ key }) => key).sort());
+    expect(sortedKeys(SWIPE_TEXT[lang])).toEqual(SWIPE_DIRS.map(({ key }) => key).sort());
+  });
+
+  it("has matching nonblank localized color-token keys (English uses token names)", () => {
+    expect(sortedKeys(COLOR_TOKEN_TEXT)).toEqual(languages.filter((lang) => lang !== "en").sort());
+    for (const [lang, labels] of Object.entries(COLOR_TOKEN_TEXT)) {
+      expect(sortedKeys(labels), lang).toEqual(sortedKeys(COLOR_TOKEN_TEXT.ja));
+      nonemptyStrings(labels, `COLOR_TOKEN_TEXT.${lang}`);
+    }
+  });
+
+  it("keeps navigation and FAB icons aligned by translation index", () => {
+    for (const table of [NAV_TABS, FAB_MENU_TABS]) {
+      for (const lang of languages) expect(table[lang].map(({ icon }) => icon), lang).toEqual(table.en.map(({ icon }) => icon));
+    }
+  });
+});
+
+describe("LANG_FONT coverage", () => {
+  it("has exactly one entry for each offered language", () => {
+    expect(sortedKeys(LANG_FONT)).toEqual([...languages].sort());
+  });
+
+  it("deliberately requires no extra font for English", () => {
+    expect(LANG_FONT.en).toBeNull();
+  });
+
+  it.each([
+    ["ja", "JP"], ["zh", "SC"], ["ko", "KR"],
+  ] as const)("supplies the matching Noto font family and download query for %s", (lang, script) => {
+    const font = LANG_FONT[lang];
+    expect(font).not.toBeNull();
+    expect(font?.family).toBe(`'Noto Sans ${script}'`);
+    expect(font?.google).toBe(`Noto+Sans+${script}:wght@400;500;600;700`);
+  });
+});

--- a/lib/project.test.ts
+++ b/lib/project.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { isProject, projectFileName, readProject } from "./project";
+import { KIND_ORDER, VARIANTS, type Doc, type Item } from "./tokens";
+
+const item = (): Item => ({ id: "item", kind: "button", label: "Save", icon: null, variant: "filled" });
+const doc = (): Doc => ({
+  title: "Sketch", brief: "A small app", paletteKey: "purple", frame: "phone",
+  groups: [{ id: "group", x: -12.5, y: 0, axis: "x", items: [item()] }],
+  frames: [{ id: "frame", name: "Home", x: 0, y: -10 }],
+});
+const withItem = (patch: Record<string, unknown>) => {
+  const value = doc();
+  return { ...value, groups: [{ ...value.groups[0], items: [{ ...item(), ...patch }] }] };
+};
+
+describe("isProject", () => {
+  it("accepts a current document without changing it", () => {
+    const value = doc();
+    const before = structuredClone(value);
+    expect(isProject(value)).toBe(true);
+    expect(value).toEqual(before);
+  });
+
+  it("accepts legacy minimal documents without supplying defaults", () => {
+    const legacy = { groups: [], frames: [{ id: "f", name: "Home", x: 0, y: 0 }] };
+    expect(isProject(legacy)).toBe(true);
+    expect(legacy).not.toHaveProperty("platform");
+    expect(legacy.frames[0]).not.toHaveProperty("w");
+  });
+
+  it.each([undefined, "android", "web"])("accepts platform %s", (platform) => {
+    expect(isProject({ ...doc(), platform })).toBe(true);
+  });
+
+  it.each([null, "ios", "", 0, {}, true])("rejects platform %j", (platform) => {
+    expect(isProject({ ...doc(), platform })).toBe(false);
+  });
+
+  it.each([null, undefined, true, 42, "{}", [], {}, { groups: [] }, { frames: [] },
+    { groups: null, frames: [] }, { groups: {}, frames: [] }, { groups: [], frames: {} },
+  ].map((value) => [value]))("rejects invalid document shape %# %o", (value) => {
+    expect(isProject(value)).toBe(false);
+  });
+
+  it.each(KIND_ORDER)("accepts registered kind %s", (kind) => {
+    expect(isProject(withItem({ kind }))).toBe(true);
+  });
+
+  it.each(VARIANTS)("accepts registered variant $key", ({ key }) => {
+    expect(isProject(withItem({ variant: key }))).toBe(true);
+  });
+
+  it.each([
+    { id: 1 }, { x: NaN }, { x: Infinity }, { x: "0" }, { y: -Infinity }, { y: null },
+    { axis: "z" }, { axis: undefined }, { items: [] }, { items: null }, { items: {} }, { items: [null] },
+  ])("rejects invalid group fields %# %o", (patch) => {
+    const value = doc();
+    expect(isProject({ ...value, groups: [{ ...value.groups[0], ...patch }] })).toBe(false);
+  });
+
+  it("checks every group, frame and item, not only the first", () => {
+    const value = doc();
+    expect(isProject({ ...value, groups: [...value.groups, null] })).toBe(false);
+    expect(isProject({ ...value, frames: [...value.frames, null] })).toBe(false);
+    expect(isProject({ ...value, groups: [{ ...value.groups[0], items: [item(), null] }] })).toBe(false);
+  });
+
+  it("accepts vertical groups and optional item fields including empty strings", () => {
+    const value = withItem({ icon: "save", supporting: "", note: "", selected: 0,
+      corners: { tl: 0, tr: 4, bl: 8, br: 12 },
+      tabs: [{ label: "One", icon: "home" }, { label: "Two", icon: null }, { label: "" }],
+    });
+    value.groups[0].axis = "y";
+    expect(isProject(value)).toBe(true);
+    expect(isProject(withItem({ tabs: [] }))).toBe(true);
+  });
+
+  it.each([
+    { id: undefined }, { id: 1 }, { kind: "unknown" }, { kind: null }, { label: 1 },
+    { icon: undefined }, { icon: 1 }, { variant: "unknown" }, { variant: undefined },
+    { supporting: null }, { note: 1 }, { selected: NaN }, { selected: Infinity }, { selected: "0" },
+    { corners: null }, { corners: {} }, { corners: { tl: 0, tr: 0, bl: 0 } },
+    { corners: { tl: "0", tr: 0, bl: 0, br: 0 } }, { corners: { tl: 0, tr: 0, bl: 0, br: Infinity } },
+    { tabs: null }, { tabs: {} }, { tabs: [null] }, { tabs: [{ icon: "home" }] },
+    { tabs: [{ label: 1 }] }, { tabs: [{ label: "Home", icon: 1 }] },
+  ])("rejects invalid item fields %# %o", (patch) => {
+    expect(isProject(withItem(patch))).toBe(false);
+  });
+
+  it.each([
+    { id: null }, { name: 1 }, { x: Infinity }, { x: "0" }, { y: NaN },
+    { w: 0 }, { w: -1 }, { w: Infinity }, { w: "100" }, { w: null },
+    { h: 0 }, { h: -1 }, { h: NaN }, { h: "100" }, { h: null }, { note: false },
+  ])("rejects invalid frame fields %# %o", (patch) => {
+    const value = doc();
+    expect(isProject({ ...value, frames: [{ ...value.frames[0], ...patch }] })).toBe(false);
+  });
+
+  it("accepts positive fractional frame dimensions and an empty note", () => {
+    const value = doc();
+    expect(isProject({ ...value, frames: [{ ...value.frames[0], w: 0.5, h: 800, note: "" }] })).toBe(true);
+  });
+});
+
+describe("projectFileName", () => {
+  it.each([
+    ["", "m3e-canvas.json"], [" \t\n ", "m3e-canvas.json"],
+    ['\\/:*?"<>|', "m3e-canvas.json"],
+    ["  My\t app\n name  ", "m3e-canvas My app name.json"],
+    ['a\\b/c:d*e?f"g<h>i|j', "m3e-canvas a b c d e f g h i j.json"],
+    ["設計 한국어 🎨.v2", "m3e-canvas 設計 한국어 🎨.v2.json"],
+  ])("sanitizes %j to %j", (title, expected) => {
+    expect(projectFileName({ ...doc(), title })).toBe(expected);
+  });
+});
+
+describe("readProject", () => {
+  it("reads a real File as JSON without relying on its name or MIME type", async () => {
+    const value = doc();
+    await expect(readProject(new File([JSON.stringify(value)], "sketch.txt", { type: "text/plain" }))).resolves.toEqual(value);
+  });
+
+  it("preserves a legacy file and unknown fields for the editor's migration step", async () => {
+    const legacy = { groups: [], frames: [], futureField: { keep: true } };
+    await expect(readProject(new File([JSON.stringify(legacy)], "old.json"))).resolves.toEqual(legacy);
+  });
+
+  it.each(["", "{", "null", "[]", '{"groups":[],"frames":{}}'])("returns null for invalid file contents %j", async (text) => {
+    await expect(readProject(new File([text], "bad.json"))).resolves.toBeNull();
+  });
+
+  it("returns null for valid JSON with an invalid nested item", async () => {
+    await expect(readProject(new File([JSON.stringify(withItem({ kind: "unknown" }))], "bad.json"))).resolves.toBeNull();
+  });
+
+  it("returns null when reading the File fails", async () => {
+    const file = new File([], "unreadable.json");
+    const read = vi.spyOn(file, "text").mockRejectedValue(new Error("Read failed"));
+    try {
+      await expect(readProject(file)).resolves.toBeNull();
+    } finally {
+      read.mockRestore();
+    }
+  });
+});

--- a/lib/share.test.ts
+++ b/lib/share.test.ts
@@ -1,0 +1,160 @@
+import { deflateRawSync, inflateRawSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DOC_PARAM, DOCZ_PARAM, hasShareHash, readShareHash, shareable, shareLink } from "./share";
+import type { Doc, Item } from "./tokens";
+
+const doc = (): Doc => ({
+  title: "設計 中文 한국어 🎨 + & # %", brief: "First line\nSecond line", paletteKey: "purple", frame: "phone", platform: "web",
+  frames: [{ id: "f", name: "Home", x: 0, y: 0, w: 1280, h: 800, note: "Keep frame note", noteHistory: ["Private frame draft"] }],
+  groups: [{ id: "g", x: -10, y: 20, axis: "x", items: [
+    { id: "i", kind: "image", label: "画像", icon: null, variant: "filled", src: "data:image/png;base64,AAAA", note: "Keep item note", noteHistory: ["Private item draft"] },
+    { id: "remote", kind: "image", label: "Public image", icon: null, variant: "filled", src: "https://example.test/image.png" },
+  ] }],
+});
+const plainHash = (value: unknown) => `#doc=${encodeURIComponent(JSON.stringify(value))}`;
+const packedHash = (text: string) => `#docz=${deflateRawSync(Buffer.from(text)).toString("base64url")}`;
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("shareable", () => {
+  it("removes every frame/item history and local image while keeping authored content", () => {
+    const value = doc();
+    value.frames.push({ ...value.frames[0], id: "f2" });
+    value.groups.push({ ...structuredClone(value.groups[0]), id: "g2" });
+    const result = shareable(value);
+    expect(result).toEqual({
+      ...value,
+      frames: value.frames.map(({ noteHistory: _history, ...frame }) => frame),
+      groups: value.groups.map((group) => ({ ...group, items: [
+        { id: "i", kind: "image", label: "画像", icon: null, variant: "filled", note: "Keep item note" },
+        { id: "remote", kind: "image", label: "Public image", icon: null, variant: "filled", src: "https://example.test/image.png" },
+      ] })),
+    });
+  });
+
+  it.each(["http://example.test/a.png", "https://example.test/a.png?x=1&y=2"])("preserves public source %s", (src) => {
+    const value = doc();
+    value.groups[0].items[0].src = src;
+    expect(shareable(value).groups[0].items[0].src).toBe(src);
+  });
+
+  it.each([undefined, "", "data:image/png;base64,AAAA", "blob:https://example.test/id", "/image.png", "//example.test/image.png", "file:///image.png"])("omits non-public source %s", (src) => {
+    const value = doc();
+    value.groups[0].items[0].src = src;
+    expect(shareable(value).groups[0].items[0]).not.toHaveProperty("src");
+  });
+
+  it("does not mutate or reuse the edited document's frame/group/item objects", () => {
+    const value = doc();
+    const before = structuredClone(value);
+    const result = shareable(value);
+    expect(value).toEqual(before);
+    expect(result).not.toBe(value);
+    expect(result.frames).not.toBe(value.frames);
+    expect(result.groups).not.toBe(value.groups);
+    expect(result.frames[0]).not.toBe(value.frames[0]);
+    expect(result.groups[0]).not.toBe(value.groups[0]);
+    expect(result.groups[0].items).not.toBe(value.groups[0].items);
+    result.groups[0].items.forEach((item: Item, index) => expect(item).not.toBe(value.groups[0].items[index]));
+    expect(shareable(result)).toEqual(result);
+  });
+
+  it("supports an empty canvas", () => {
+    const value = { ...doc(), groups: [], frames: [] };
+    expect(shareable(value)).toEqual(value);
+  });
+});
+
+describe("shareLink and readShareHash", () => {
+  it("keeps the public wire parameter names stable", () => {
+    expect(DOC_PARAM).toBe("doc");
+    expect(DOCZ_PARAM).toBe("docz");
+  });
+
+  it("round-trips Unicode with native raw-deflate streams and unpadded base64url", async () => {
+    const value = doc();
+    const before = structuredClone(value);
+    const base = "https://example.test/canvas/?mode=edit";
+    // No mock or conditional skip: supported Node must exercise real Web Streams.
+    const link = await shareLink(value, base);
+    expect(link).toMatch(/^https:\/\/example\.test\/canvas\/\?mode=edit#docz=[A-Za-z0-9_-]+$/);
+    const hash = new URL(link).hash;
+    const bytes = Buffer.from(hash.slice("#docz=".length), "base64url");
+    expect(JSON.parse(inflateRawSync(bytes).toString("utf8"))).toEqual(shareable(value));
+    await expect(readShareHash(hash)).resolves.toEqual(shareable(value));
+    expect(value).toEqual(before);
+  });
+
+  it("round-trips percent-encoded JSON when CompressionStream is unavailable", async () => {
+    vi.stubGlobal("CompressionStream", undefined);
+    vi.stubGlobal("DecompressionStream", undefined);
+    const value = doc();
+    const base = "https://example.test/subdir/?keep=1";
+    const link = await shareLink(value, base);
+    expect(link).toBe(`${base}#doc=${encodeURIComponent(JSON.stringify(shareable(value)))}`);
+    await expect(readShareHash(new URL(link).hash)).resolves.toEqual(shareable(value));
+  });
+
+  it("reads independently generated raw-deflate payloads", async () => {
+    await expect(readShareHash(packedHash(JSON.stringify(doc())))).resolves.toEqual(doc());
+  });
+
+  it("reads plain JSON with or without a leading hash and alongside unrelated parameters", async () => {
+    const hash = plainHash(doc());
+    await expect(readShareHash(hash.slice(1))).resolves.toEqual(doc());
+    await expect(readShareHash(`#other=1&${hash.slice(1)}&last=2`)).resolves.toEqual(doc());
+  });
+
+  it("accepts a legacy document without adding defaults", async () => {
+    const legacy = { groups: [], frames: [] };
+    await expect(readShareHash(plainHash(legacy))).resolves.toEqual(legacy);
+  });
+
+  it("prefers a nonempty compressed document to a plain document", async () => {
+    const packed = { ...doc(), title: "Compressed wins" };
+    await expect(readShareHash(`${plainHash(doc())}&${packedHash(JSON.stringify(packed)).slice(1)}`)).resolves.toEqual(packed);
+  });
+
+  it("uses plain JSON when the compressed parameter is empty", async () => {
+    await expect(readShareHash(`${plainHash(doc())}&docz=`)).resolves.toEqual(doc());
+  });
+
+  it("does not silently fall back to plain JSON after compressed corruption", async () => {
+    await expect(readShareHash(`${plainHash(doc())}&docz=!!!`)).resolves.toBeNull();
+  });
+
+  it.each(["", "#", "#unrelated=1", "#doc=", "#docz=", "#doc=%7B", "#doc=%FF", "#docz=!!!", "#docz=A", "#docz=AAAA"])("returns null for missing or broken payload %s", async (hash) => {
+    await expect(readShareHash(hash)).resolves.toBeNull();
+  });
+
+  it.each([null, [], {}, { groups: [], frames: null }, { ...doc(), platform: "ios" },
+    { ...doc(), groups: [{ ...doc().groups[0], items: [] }] },
+  ].map((value) => [value]))("rejects non-project JSON in either encoding: %# %o", async (value) => {
+    await expect(readShareHash(plainHash(value))).resolves.toBeNull();
+    await expect(readShareHash(packedHash(JSON.stringify(value)))).resolves.toBeNull();
+  });
+
+  it("returns null for valid deflate containing invalid JSON", async () => {
+    await expect(readShareHash(packedHash("not JSON"))).resolves.toBeNull();
+  });
+
+  it("returns null for a truncated compressed stream", async () => {
+    const bytes = deflateRawSync(Buffer.from(JSON.stringify(doc())));
+    await expect(readShareHash(`#docz=${bytes.subarray(0, bytes.length - 8).toString("base64url")}`)).resolves.toBeNull();
+  });
+
+  it("returns null for compressed input when decompression is unavailable", async () => {
+    vi.stubGlobal("DecompressionStream", undefined);
+    await expect(readShareHash(packedHash(JSON.stringify(doc())))).resolves.toBeNull();
+  });
+});
+
+describe("hasShareHash", () => {
+  it.each(["#doc=", "#docz=", "doc=x", "docz=x", "#other=1&doc=bad", "#docz=!!!"])("recognizes parameter presence without validating %s", (hash) => {
+    expect(hasShareHash(hash)).toBe(true);
+  });
+
+  it.each(["", "#", "#other=doc", "#document=x", "#DOC=x", "#other=docz%3Dx", "#mydoc=x"])("does not mistake unrelated hash %s for a project", (hash) => {
+    expect(hasShareHash(hash)).toBe(false);
+  });
+});


### PR DESCRIPTION
Covers the three untested lib modules. All green with the existing suites (292/292 locally: npm test + typecheck + build clean).

Added (pure test files, zero prod/config changes):
- lib/project.test.ts — isProject validation (platforms, kinds, variants, groups/items/frames, corners, tabs), projectFileName sanitization, readProject incl. legacy + unreadable-File paths
- lib/share.test.ts — shareable() redaction + no-mutation, docz round-trip validated against independent node:zlib inflation, doc fallback both ways, encoding precedence, truncated/corrupt payloads, hasShareHash
- lib/i18n.parity.test.ts — every language same keys, no empty strings, placeholder consistency, KIND/TRANSITION/SWIPE + color-token coverage, LANG_FONT incl. null English

Notes: private UI/KO maps are read via anchored source patterns that fail loudly on reformat (no prod export added); stream tests target the repo's Node 22 runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 236 test cases for the project, share, and i18n modules with zero production or config changes.

**Coverage**
- `lib/project.test.ts` validates documents, sanitizes file names, and reads files including legacy and unreadable inputs.
- `lib/share.test.ts` covers payload redaction, round-trips, and rejection of corrupt, truncated, or invalid payloads.
- `lib/i18n.parity.test.ts` checks key parity, nonblank strings, placeholder consistency, and editor-token coverage across all languages.
- The i18n tests read private dictionaries via anchored source patterns that fail loudly on reformat, without widening the production API.
- Tests target the repo's Node 22 runtime.

<sup>Written for commit 29ad20f9e441dc02016d5d60d73c503679676070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

