### PR TITLE
Prevent canvas shortcuts while project and AI dialogs are open

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2609,8 +2609,8 @@ export default function Page() {
           t.tagName === "TEXTAREA" ||
           t.isContentEditable);
       if (typing) return;
-      // the confirm dialog and the preview own the keyboard while they are up
-      if (confirmClear || previewId !== null) return;
+      // dialogs and the preview own the keyboard while they are up
+      if (confirmClear || pendingImport !== null || shareOpen || previewId !== null) return;
       const mod = e.ctrlKey || e.metaKey;
       if (mod && e.key.toLowerCase() === "z") {
         e.preventDefault();
@@ -2711,6 +2711,8 @@ export default function Page() {
     selectedFrameId,
     deleteFrame,
     confirmClear,
+    pendingImport,
+    shareOpen,
     previewId,
     editAccess,
   ]);


### PR DESCRIPTION
## What and why

The project-import confirmation and Ask an AI dialog leave canvas keyboard shortcuts active. Select a part, open either dialog, focus a dialog button, and press Delete: the selected part is deleted behind the dialog. Undo, duplicate, paste, nudge and view shortcuts can also reach the canvas.

Include `pendingImport` and `shareOpen` in the existing keyboard guard and its effect dependencies. Canvas shortcuts pause while either dialog is open and resume when it closes. The dialogs retain their own input, Escape, Enter and button behavior.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (449 tests across 14 files)
- [x] `NEXT_PUBLIC_BASE_PATH=/m3e-canvas npm run build` passes
- [x] No UI strings or prompt text changed
- [x] Verified the editor with Playwright at 1440×1000 and 390×844
- [x] Manually retested the patched editor locally and found no issues

Reproduced the deletion on the original code in both dialogs. Verified the fix using Chrome with Playwright: 19 shortcut combinations leave the document and view unchanged with a dialog button focused; typing and Backspace still work in the AI text field; Escape cancels, Enter confirms import, and Space activates Cancel. Delete and Undo work again after closing the AI dialog. An available redo remains blocked while confirming an import. No page errors, console errors or warnings were observed.

The AI dialog was tested at desktop size; it is not offered by the phone editor. The shared import confirmation was also exercised at phone size. Automated browser checks covered Chrome only and did not use physical mobile devices. The browser checks used a temporary script without adding dependencies or a new test framework to the repository.

## Screenshots

No visual changes. The fix prevents document mutations behind the existing dialogs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents canvas keyboard shortcuts from firing while the project import confirmation and Ask an AI dialog are open. Previously, shortcuts like Delete, Undo, duplicate, paste, nudge, and view shortcuts reached the canvas behind the dialogs, mutating the document. Now those shortcuts pause while either dialog is open and resume when it closes; the dialogs keep their own input, Escape, Enter, and button behavior.

<sup>Written for commit 51f3c3cddadb925fff563f43c99dda772998e8b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

