### PR TITLE
Fix conflicting frame background styles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3363,7 +3363,8 @@ export default function Page() {
                           width: w + BEZEL * 2,
                           height: h + BEZEL * 2,
                           borderRadius: radius + BEZEL,
-                          background: draftBusy ? DRAFT_GRADIENT(p) : p.inverseSurface,
+                          backgroundColor: p.inverseSurface,
+                          backgroundImage: draftBusy ? DRAFT_GRADIENT(p) : undefined,
                           backgroundSize: draftBusy ? "300% 300%" : undefined,
                           animation: draftBusy ? "m3e-drift 3s ease-in-out infinite" : undefined,
                           boxShadow: on


### PR DESCRIPTION
## What and why

Changing the editor's color palette causes React to report a conflict between `background` and `backgroundSize`, even when no AI draft is running. The frame style declares both properties; React's conflict check still considers `backgroundSize` when its value is `undefined`. During drafting, updating the background shorthand can also reset the gradient size while the animation is running.

Set the frame bezel's color with `backgroundColor` and its draft gradient with `backgroundImage`. This preserves the existing `300% 300%` sizing and drift animation, and clears the gradient when drafting finishes. The conflicting declarations are already on `main`, introduced in 5c83ac6f437153b4df4d2348c4f94c4ff71b864a.

## How I checked it

- Reproduced the console error by switching from Purple to Blue without starting an AI draft. Repeated the same interaction after the fix with no console warnings/errors.
- Also reproduced the original console error during drafting: start an AI draft with a delayed local mock response, then change the palette while it is pending.
- Repeated palette and light/dark changes after the fix using the computer-use tool in the in-app browser at 1280 × 720. No new console warnings/errors or framework error overlay appeared; the gradient kept its size and animation.
- Verified successful generation, restoring the previous design, and an invalid model response. Completed/failed drafts returned to a solid bezel with no background image or animation. AI responses were simulated locally; no external provider was called.

- [x] `npm run typecheck` passes
- [x] `npm test` passes (449 tests)
- [x] `npm run build` passes
- [x] Tried it in the desktop editor; the AI draft entry point is desktop-only
