### PR TITLE
Prevent initial layout shifts while the icon font loads

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,6 +26,11 @@ body {
   letter-spacing: normal;
   text-transform: none;
   display: inline-block;
+  /* Reserve the glyph box before the font loads, not the ligature text width. */
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  overflow: hidden;
   white-space: nowrap;
   word-wrap: normal;
   direction: ltr;

--- a/components/IconPicker.tsx
+++ b/components/IconPicker.tsx
@@ -104,12 +104,12 @@ export function IconPicker({
 
   return (
     <div>
-      {/* hidden probes — measured before paint, so nothing broken ever renders */}
+      {/* Hidden probes need intrinsic text widths to distinguish missing glyphs. */}
       <div
         aria-hidden
         style={{ position: "fixed", left: -99999, top: 0, visibility: "hidden", pointerEvents: "none" }}
       >
-        <span ref={refEl} className="msr" style={{ fontSize: 24 }}>
+        <span ref={refEl} className="msr" style={{ fontSize: 24, width: "auto" }}>
           search
         </span>
         {unknown.map((c) => (
@@ -120,7 +120,7 @@ export function IconPicker({
               else probeEls.current.delete(c.n);
             }}
             className="msr"
-            style={{ fontSize: 24 }}
+            style={{ fontSize: 24, width: "auto" }}
           >
             {c.n}
           </span>


### PR DESCRIPTION
## What and why

On a cold load, Material Symbols ligature names reserve text-sized space while the icon font is loading, stretching toolbar buttons and shifting the parts palette. Reserve a non-shrinking 1em square for `.msr` icons and clip overflow so loading the font does not change their layout. The box follows each icon's existing font size.

The icon picker's hidden reference and candidate probes explicitly retain intrinsic widths, so missing glyphs can still be detected and filtered.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (449 tests)
- [x] `npm run build` passes
- [x] New or changed UI strings and prompt text exist in Japanese, English, Chinese and Korean (no strings changed)
- [x] Tried it in the editor (and on a phone, if the change touches the phone editor): desktop and mobile Chromium viewports, 1440px and 390px wide

Held the Material Symbols font request, measured the icons and their parent containers, then released the request and confirmed the font loaded. All 122 desktop icons and 14 mobile icons retained the same dimensions and parent positions. Temporarily restoring the previous CSS reproduced layout changes in both viewports. Also inspected the initial-frame recording and the loaded desktop/mobile rendering.

Exercised the actual icon picker with valid names (`search`, `tv`) and a deliberately nonexistent name. Valid icons remained selectable and the nonexistent candidate was excluded, including when searched directly.

## Screenshots

Visual reproduction: open a fresh browser context with a delayed Material Symbols font request. Before this change, the selected toolbar button expands horizontally and the palette shifts when the font arrives. With this change, icon space is reserved from the first frame.
