### PR TITLE
Fix icon picker dismissal across desktop and mobile 

### DIFF
--- a/components/IconPicker.tsx
+++ b/components/IconPicker.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Palette } from "@/lib/tokens";
 import { t, useLang } from "@/lib/i18n";
+import { IconBtn } from "./ui";
 
 type IconMeta = { n: string; p: number; t: string };
 
@@ -21,10 +22,12 @@ const SHOWN = 240;
 export function IconPicker({
   value,
   onChange,
+  onClose,
   palette,
 }: {
   value: string | null;
   onChange: (icon: string | null) => void;
+  onClose: () => void;
   palette: Palette;
 }) {
   const lang = useLang();
@@ -37,6 +40,17 @@ export function IconPicker({
 
   const refEl = useRef<HTMLSpanElement>(null);
   const probeEls = useRef<Map<string, HTMLElement>>(new Map());
+
+  useEffect(() => {
+    const key = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      // Dismiss the picker without clearing the editor's selection.
+      e.stopPropagation();
+      onClose();
+    };
+    document.addEventListener("keydown", key, true);
+    return () => document.removeEventListener("keydown", key, true);
+  }, [onClose]);
 
   useEffect(() => {
     if (cache) return;
@@ -136,6 +150,7 @@ export function IconPicker({
             search
           </span>
           <input
+            aria-label={t("searchIcons", lang)}
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder={icons ? t("searchIcons", lang) : "…"}
@@ -153,6 +168,7 @@ export function IconPicker({
             }}
           />
         </div>
+        <IconBtn icon="close" p={palette} size={40} onClick={onClose} title={t("close", lang)} />
       </div>
 
       <div
@@ -174,6 +190,8 @@ export function IconPicker({
           <button
             key={i.n}
             title={i.n}
+            aria-label={i.n}
+            aria-pressed={value === i.n}
             onClick={() => onChange(i.n)}
             style={{
               aspectRatio: "1",

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -930,10 +930,11 @@ export function Inspector({
                   <button
                     onClick={() => {
                       setSlotKey(`tab:${i}`);
-                      setPickerOpen(true);
+                      setPickerOpen(!on);
                     }}
                     title={t("changeIcon", lang)}
                     aria-label={t("changeIcon", lang)}
+                    aria-expanded={on}
                     className="m3-press"
                     style={{
                       width: 40,
@@ -1074,6 +1075,7 @@ export function Inspector({
           <IconPicker
             value={activeSlot.value}
             onChange={(icon) => change(setIconSlot(item, activeSlot.key, icon))}
+            onClose={() => setPickerOpen(false)}
             palette={p}
           />
         </div>

--- a/components/Mobile.tsx
+++ b/components/Mobile.tsx
@@ -117,7 +117,8 @@ export function MobileInspector({
   useEffect(() => {
     setSlotKey(iconSlotsOf(item)[0]?.key ?? "icon");
     setPickerOpen(false);
-  }, [item.id]);
+    setTabSlot(null);
+  }, [item.id, item.kind, item.tabs?.length]);
   const activeSlot = slots.find((s) => s.key === slotKey) ?? slots[0];
   const variants = spec.hasVariant ? variantsOf(item.kind) : [];
   const tabs: NavTab[] = item.tabs ?? [];
@@ -203,7 +204,7 @@ export function MobileInspector({
                   />
                 )}
                 {item.kind !== "tabs" && !isSelect && (
-                  <IconBtn icon={tab.icon || "add"} p={p} size={48} on={tabSlot === i} onClick={() => setTabSlot(tabSlot === i ? null : i)} title={t("changeIcon", lang)} />
+                  <IconBtn icon={tab.icon || "add"} p={p} size={48} on={tabSlot === i} onClick={() => { setTabSlot(tabSlot === i ? null : i); setPickerOpen(false); }} title={t("changeIcon", lang)} />
                 )}
                 {item.kind !== "toolbar" && (
                   <Field value={tab.label} onChange={(label) => onChange({ tabs: tabs.map((x, j) => (j === i ? { ...x, label } : x)) })} placeholder={t("label", lang)} p={p} height={48} />
@@ -232,7 +233,7 @@ export function MobileInspector({
           )}
           {tabSlot !== null && tabs[tabSlot] && (
             <div style={{ marginTop: 8 }}>
-              <IconPicker value={tabs[tabSlot].icon || null} onChange={(icon) => onChange(setIconSlot(item, `tab:${tabSlot}`, icon))} palette={p} />
+              <IconPicker value={tabs[tabSlot].icon || null} onChange={(icon) => onChange(setIconSlot(item, `tab:${tabSlot}`, icon))} onClose={() => setTabSlot(null)} palette={p} />
             </div>
           )}
         </Row>
@@ -247,6 +248,7 @@ export function MobileInspector({
                 <button
                   key={s.key}
                   onClick={() => {
+                    setTabSlot(null);
                     setSlotKey(s.key);
                     setPickerOpen(!(on && pickerOpen));
                   }}
@@ -300,7 +302,7 @@ export function MobileInspector({
           </div>
           {pickerOpen && (
             <div style={{ marginTop: 8 }}>
-              <IconPicker value={activeSlot.value} onChange={(icon) => onChange(setIconSlot(item, activeSlot.key, icon))} palette={p} />
+              <IconPicker value={activeSlot.value} onChange={(icon) => onChange(setIconSlot(item, activeSlot.key, icon))} onClose={() => setPickerOpen(false)} palette={p} />
             </div>
           )}
         </Row>


### PR DESCRIPTION
## What and why

Opening a navigation item's icon list previously left no explicit way to dismiss it, and clicking the active icon again kept it open. Add the existing round `IconBtn` close control beside search and support Escape without clearing the canvas selection. The desktop item icon now toggles its picker, while switching to another icon keeps the picker open for that slot.

On mobile, reset the open icon slot when the selected item, kind, or item count changes so a removed slot's picker cannot reappear when items are added again. Keep only one icon picker open at a time. Reuse existing palette tokens and all four translations; expose the search field, selected icons, and desktop trigger state to assistive technology.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (449 tests, 14 files)
- [x] `npm run build` passes
- [x] New or changed UI strings and prompt text exist in Japanese, English, Chinese and Korean (existing `close` and `searchIcons` translations reused)
- [x] Tried it in the editor and at a 390 × 844 phone viewport

Manual checks: desktop close button, same-icon toggle, Escape from search without losing the selected navigation bar, and choosing an icon before closing. On mobile, verified close and Escape leave the editing sheet open; reducing four items to two and restoring four does not reopen the old picker. Visually checked the search/close row and icon grid at desktop and phone sizes.

Validation used Node 22.22.0. Installed the missing native Rolldown binding locally to run Vitest; no dependency or lockfile changes are included.


## Screenshots

The new close button sits beside the search field. Escape and active-icon toggle behavior are covered by the manual checks above.

### Desktop (1280 × 720)

| Before | After |
| --- | --- |
| ![Desktop before](https://raw.githubusercontent.com/Razshy/m3e-canvas/3f89af46f958d833ec8a50ce16c24428201b3797/desktop-before.png) | ![Desktop after](https://raw.githubusercontent.com/Razshy/m3e-canvas/3f89af46f958d833ec8a50ce16c24428201b3797/desktop-after.png) |

### Phone (390 × 844)

| Before | After |
| --- | --- |
| ![Phone before](https://raw.githubusercontent.com/Razshy/m3e-canvas/3f89af46f958d833ec8a50ce16c24428201b3797/phone-before.png) | ![Phone after](https://raw.githubusercontent.com/Razshy/m3e-canvas/3f89af46f958d833ec8a50ce16c24428201b3797/phone-after.png) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes icon picker dismissal across desktop and mobile. Previously the picker had no explicit close control and clicking the active icon again kept it open; now a close button and Escape key dismiss it without clearing the canvas selection, and the desktop trigger toggles the picker open and closed.

- Mobile resets the open icon slot when the selected item, kind, or tab count changes, so a removed slot's picker can't reappear when items are added back.
- Adds `aria-expanded`, `aria-pressed`, and search field labels for assistive technology.

<sup>Written for commit f454f172c5d70fd3d70f3db2ed8b8dbc44b4a0ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

