### PR TITLE
Add a per-group lock to the Layers panel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1125,6 +1125,8 @@ export default function Page() {
       setSelectedFrameId(null);
       setSelectedLinkId(null);
       setRightTab("edit");
+      /* a locked group stays selectable, but dragging it does nothing */
+      if (g.locked) return;
       const gg: Gesture = { kind: "group", id: g.id, sx: e.clientX, sy: e.clientY, gx: g.x, gy: g.y, moved: false, overBin: false };
       gestureRef.current = gg;
       setGesture(gg);
@@ -1142,6 +1144,8 @@ export default function Page() {
     setSelectedFrameId(null);
     setSelectedLinkId(null);
     setRightTab("edit");
+    /* a locked group's part stays selectable, but dragging it does nothing */
+    if (g.locked) return;
     setPressedId(item.id);
     const d: DragState = {
       item,
@@ -1680,6 +1684,8 @@ export default function Page() {
     setGroups((prev) =>
       prev
         .map((g) => {
+          /* Delete / Backspace leaves a locked group and its parts alone */
+          if (g.locked) return g;
           if (g.free) return collapseFree({ ...g, items: g.items.filter((it) => !ids.has(it.id)) }, widthsRef.current);
           let x = g.x;
           let y = g.y;
@@ -2876,6 +2882,12 @@ export default function Page() {
     setGroups((gs) => [...gs.filter((g) => !inFrame.has(g.id)), ...ordered]);
   };
 
+  /** flips a group's lock from its row's lock icon in the Layers panel */
+  const toggleGroupLock = (id: string) => {
+    snapshot();
+    setGroups((prev) => prev.map((g) => (g.id === id ? { ...g, locked: !g.locked } : g)));
+  };
+
   /** The parts of one group in a new order: reading order for a connected run, back to
    *  front for a free group. Inside a free group a hidden run keeps its slots, handed out
    *  again in the new order, so reordering a list really moves its rows. */
@@ -3252,6 +3264,7 @@ export default function Page() {
                       setRightTab("edit");
                     }}
                     onReorder={reorderLayers}
+                    onToggleLock={toggleGroupLock}
                     onReorderItems={reorderGroupItems}
                     onDragging={onLayerDragging}
                   />

--- a/components/Layers.tsx
+++ b/components/Layers.tsx
@@ -37,6 +37,8 @@ function Row({
   onSelect,
   open,
   onToggle,
+  locked,
+  onLock,
   onDragging,
   children,
 }: {
@@ -50,6 +52,10 @@ function Row({
   /** set when the row can open to show what it holds */
   open?: boolean;
   onToggle?: () => void;
+  /** the group's lock, so the row shows which state it is in */
+  locked?: boolean;
+  /** flips the group's lock; set only on a whole group's row */
+  onLock?: () => void;
   onDragging: (dragging: boolean) => void;
   children?: ReactNode;
 }) {
@@ -101,6 +107,17 @@ function Row({
           <span style={{ display: "inline-flex", gap: 2, color: on ? p.onSecondaryContainer : p.primary }}>{icon}</span>
           <span style={{ fontSize: 12, fontWeight: depth === 0 ? 600 : 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{label}</span>
         </button>
+        {onLock && (
+          <button
+            onClick={onLock}
+            title={t(locked ? "unlock" : "lock", lang)}
+            aria-pressed={locked}
+            className="m3-press"
+            style={{ width: 28, height: 28, borderRadius: 14, border: "none", background: "transparent", color: locked ? (on ? p.onSecondaryContainer : p.primary) : p.outline, cursor: "pointer", padding: 0, display: "grid", placeItems: "center", flex: "0 0 auto" }}
+          >
+            <Icon name={locked ? "lock" : "lock_open"} size={20} fill={locked} />
+          </button>
+        )}
         {onToggle && (
           <button
             onClick={onToggle}
@@ -182,6 +199,7 @@ export function LayersPanel({
   selectedIds,
   onSelect,
   onReorder,
+  onToggleLock,
   onReorderItems,
   onDragging,
 }: {
@@ -197,6 +215,8 @@ export function LayersPanel({
   onSelect: (itemIds: string[], add: boolean) => void;
   /** new order, top layer first */
   onReorder: (topFirst: string[]) => void;
+  /** flips a group's lock from its row's lock icon */
+  onToggleLock: (groupId: string) => void;
   /** a group's parts in a new order: back to front for a free group, reading order for a run */
   onReorderItems: (groupId: string, ids: string[]) => void;
   /** a drag on any level starting or ending, so the page can record one undo step for the whole drag */
@@ -327,6 +347,8 @@ export function LayersPanel({
                   onSelect={(add) => onSelect(g.items.map((it) => it.id), add)}
                   open={canOpen ? open : undefined}
                   onToggle={canOpen ? () => toggle(g.id) : undefined}
+                  locked={g.locked}
+                  onLock={() => onToggleLock(g.id)}
                   onDragging={onDragging}
                 >
                   {groupBody(g, 1)}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -272,6 +272,8 @@ export const UI = {
   noLayers: { ja: "この画面には部品がありません", en: "Nothing on this screen yet", zh: "此屏幕还没有组件" },
   showParts: { ja: "中の部品を表示", en: "Show the parts inside", zh: "显示组内组件" },
   hideParts: { ja: "中の部品を隠す", en: "Hide the parts inside", zh: "隐藏组内组件" },
+  lock: { ja: "ロック", en: "Lock", zh: "锁定" },
+  unlock: { ja: "ロック解除", en: "Unlock", zh: "解锁" },
   // prompt panel
   brief: { ja: "このアプリの説明…", en: "What this app is…", zh: "这个应用的说明…" },
   appName: { ja: "アプリの名前", en: "App name", zh: "应用名称" },
@@ -436,7 +438,7 @@ export const KO: Record<UIKey, string> = {
   useThis: "이 색상 사용", fineTune: "세부 조정", dynamicColor: "동적 색상",
   dynamicOnHint: "여기 표시된 색상은 편집기 전용입니다. 실제 기기에서는 배경화면 색상을 사용합니다.",
   dynamicOffHint: "켜면 실제 기기는 배경화면 색상을 사용하고 여기의 색상은 대체 색상이 됩니다.", closeBtn: "닫기", screens: "화면 선택",
-  noLayers: "이 화면에는 아직 부품이 없습니다", showParts: "안의 부품 표시", hideParts: "안의 부품 숨기기",
+  noLayers: "이 화면에는 아직 부품이 없습니다", showParts: "안의 부품 표시", hideParts: "안의 부품 숨기기", lock: "잠금", unlock: "잠금 해제",
   brief: "이 앱에 대한 설명…", appName: "앱 이름", targetPlatform: "구현 대상", targetAndroid: "Android 네이티브 앱으로 만들기",
   targetWeb: "브라우저에서 실행되는 웹 앱으로 만들기", copyPrompt: "프롬프트 복사", back: "뒤로", close: "닫기 (Esc)", cancel: "취소", ok: "확인",
   leading: "앞쪽", trailing: "뒤쪽", home: "홈", screenN: "화면", copySuffix: " 복사본", mobileNote: "전체 기능은 데스크톱 브라우저에서 사용할 수 있습니다",

--- a/lib/project.test.ts
+++ b/lib/project.test.ts
@@ -50,9 +50,15 @@ describe("isProject", () => {
     expect(isProject(withItem({ variant: key }))).toBe(true);
   });
 
+  it.each([true, false])("accepts a group lock set to %s", (locked) => {
+    const value = doc();
+    expect(isProject({ ...value, groups: [{ ...value.groups[0], locked }] })).toBe(true);
+  });
+
   it.each([
     { id: 1 }, { x: NaN }, { x: Infinity }, { x: "0" }, { y: -Infinity }, { y: null },
     { axis: "z" }, { axis: undefined }, { items: [] }, { items: null }, { items: {} }, { items: [null] },
+    { locked: "yes" }, { locked: 1 }, { locked: null },
   ])("rejects invalid group fields %# %o", (patch) => {
     const value = doc();
     expect(isProject({ ...value, groups: [{ ...value.groups[0], ...patch }] })).toBe(false);

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -33,6 +33,7 @@ const validGroup = (group: unknown) =>
   Number.isFinite(group.x) &&
   Number.isFinite(group.y) &&
   (group.axis === "x" || group.axis === "y") &&
+  (group.locked === undefined || typeof group.locked === "boolean") &&
   Array.isArray(group.items) &&
   group.items.length > 0 &&
   group.items.every(validItem);

--- a/lib/share.test.ts
+++ b/lib/share.test.ts
@@ -63,6 +63,11 @@ describe("shareable", () => {
     const value = { ...doc(), groups: [], frames: [] };
     expect(shareable(value)).toEqual(value);
   });
+
+  it("keeps a group's lock flag", () => {
+    const value = { ...doc(), groups: [{ ...doc().groups[0], locked: true }] };
+    expect(shareable(value).groups[0].locked).toBe(true);
+  });
 });
 
 describe("shareLink and readShareHash", () => {

--- a/lib/tidy.test.ts
+++ b/lib/tidy.test.ts
@@ -120,3 +120,38 @@ describe("tidyFrame placement", () => {
     expect(Math.abs(between - below)).toBeLessThanOrEqual(1);
   });
 });
+
+describe("tidyFrame with locked groups", () => {
+  /* a locked run of two list items, with a lone list item close enough above it to fuse when unlocked */
+  const lockedRun = (): Group => ({ ...grp("g-lock", 16, 500, [part("listItem", "l1"), part("listItem", "l2")]), axis: "y", locked: true });
+  const neighbour = (): Group => grp("g-nb", 16, 412, [part("listItem", "n1")]);
+  const buttons = (): Group => grp("g-btns", 100, 60, [part("button", "b1"), part("button", "b2")]);
+  const find = (out: Group[], id: string) => out.find((g) => g.id === id)!;
+
+  it("keeps a locked group at its exact position, never merging it into a run", () => {
+    const run = lockedRun();
+    const out = tidyFrame([run, neighbour(), buttons()], frame, frames, {})!;
+    expect(find(out, "g-lock")).toEqual(run);
+  });
+
+  it("still tidies the unlocked groups as if the locked one were not there", () => {
+    const mixed = tidyFrame([lockedRun(), neighbour(), buttons()], frame, frames, {})!;
+    const solo = tidyFrame([neighbour(), buttons()], frame, frames, {})!;
+    for (const id of ["g-nb", "g-btns"]) expect(find(mixed, id)).toEqual(find(solo, id));
+    /* and tidying really did move them */
+    expect(find(mixed, "g-btns")).not.toEqual(buttons());
+    expect(find(mixed, "g-nb")).not.toEqual(neighbour());
+  });
+
+  it("merges the same runs when the group is not locked", () => {
+    const out = tidyFrame([{ ...lockedRun(), locked: undefined }, neighbour(), buttons()], frame, frames, {})!;
+    const lists = out.filter((g) => g.items.some((it) => it.kind === "listItem"));
+    expect(lists).toHaveLength(1);
+    expect(lists[0].items.map((it) => it.id).sort()).toEqual(["l1", "l2", "n1"]);
+  });
+
+  it("yields no change when every group on the screen is locked", () => {
+    const other = { ...grp("g-other", 60, 300, [part("listItem", "o1")]), locked: true };
+    expect(tidyFrame([lockedRun(), other], frame, frames, {})).toBeNull();
+  });
+});

--- a/lib/tidy.ts
+++ b/lib/tidy.ts
@@ -372,8 +372,9 @@ export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths
   const mineIds = new Set(groups.filter((g) => frameOfGroup(g, frames, widths)?.id === frame.id).map((g) => g.id));
   if (!mineIds.size) return null;
 
-  /* joining rewrites the list; the other screens' groups keep their slots */
-  const before = groups.filter((g) => mineIds.has(g.id));
+  /* joining rewrites the list; the other screens' groups keep their slots.
+   * Locked groups are finished sections: they never join, cluster or move. */
+  const before = groups.filter((g) => mineIds.has(g.id) && !g.locked);
   /* a labelled switch standing on its own on a phone screen reads as a settings row: it takes
    * the content width, label left, switch right. One on a box, in a group or on a desktop
    * screen keeps its size. */
@@ -533,11 +534,16 @@ export function tidyFrame(groups: Group[], frame: Frame, frames: Frame[], widths
   for (const m of mine) for (const it of m.items) survivorOf.set(it.id, m);
   const lastSlot = new Map<string, number>();
   groups.forEach((g, i) => {
-    if (mineIds.has(g.id)) lastSlot.set(survivorOf.get(g.items[0].id)!.id, i);
+    if (mineIds.has(g.id) && !g.locked) lastSlot.set(survivorOf.get(g.items[0].id)!.id, i);
   });
   const out: Group[] = [];
   groups.forEach((g, i) => {
     if (!mineIds.has(g.id)) {
+      out.push(g);
+      return;
+    }
+    /* a locked group keeps its position and its slot untouched */
+    if (g.locked) {
       out.push(g);
       return;
     }

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1498,6 +1498,8 @@ export type Group = {
   y: number;
   axis: Axis;
   items: Item[];
+  /** a finished section the author locked from the Layers panel: it cannot be dragged, deleted or tidied, but stays selectable */
+  locked?: boolean;
   /** a hand-made group: parts keep their own offsets (in `pos`) and move as one layer */
   free?: boolean;
   pos?: Record<string, { x: number; y: number }>;


### PR DESCRIPTION
Closes #109.


This PR implements the group-level locking discussed in the issue, toggled from a lock icon on each row in the Layers panel. Scope is exactly what was agreed there — group level only, no part- or screen-level locking, no changes to reordering (drag-only) or any other feature.


## Behaviour



- A lock icon on each group row in the Layers panel toggles `Group.locked`. Unlocked shows `lock_open` in `p.outline` (the same muted grey as the drag handle); locked shows `lock`, filled, in `p.primary`, matching the row icons.

- The row stays visible, selectable, and reorderable (drag handle) in both states. A locked group's parts can still be inspected and edited in the right sidebar.

- A locked group cannot be dragged on the canvas and cannot be deleted with Delete / Backspace; Delete still works normally for unlocked groups and loose parts.

- Tidy skips locked groups (`tidyFrame` works per group, so they are filtered out of the placement input and pushed back into the output untouched — position and layer slot preserved).

- The flag travels with the document: `isProject` in `lib/project.ts` accepts it, so it survives project-file save/load. Because `shareable()` in `lib/share.ts` spreads the group as-is and `readShareHash` validates through `isProject`, the flag also survives share links — this path is covered by a round-trip test in `lib/share.test.ts`.



## Implementation



- `Group` gains one optional field `locked?: boolean` (`lib/tokens.ts`).

- `validGroup` in `lib/project.ts` accepts `locked` as an optional boolean.

- Labels for lock/unlock exist in all four languages (ja / en / zh / ko) in `lib/i18n.ts`.

- Tests: new cases in `lib/tidy.test.ts` (locked groups stay in place and never join runs, unlocked groups still tidy, all-locked screens yield no change), `lib/project.test.ts` (isProject accepts `locked`, rejects a non-boolean), and a share-link round-trip case in `lib/share.test.ts`.



## Validation



- `npm run typecheck` — passes.

- `npx vitest run` — 14 files, 459 tests pass.

- Manual: toggled the lock on a header/nav group in the Layers panel, confirmed it cannot be dragged on the canvas or deleted with Delete / Backspace, confirmed Tidy leaves it in place while tidying the rest, and confirmed the flag survives save → reload.



Part-level or screen-level locking intentionally left out, as discussed in the issue.

https://github.com/user-attachments/assets/31b9a65d-2b8e-4ddb-ba4f-ea931d3556e1



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-group lock to the Layers panel. Locked groups can't be dragged on the canvas, deleted with Delete/Backspace, or moved by Tidy, but stay selectable and their parts remain editable.

- Each group row gains a lock toggle; unlocked shows a muted lock-open icon, locked shows a filled lock in the primary color.
- The lock flag survives project file save/load and share links.
- Lock labels ship in ja/en/zh/ko.

Closes #109.

<sup>Written for commit e69801dd7b938dc268c4f2a5cf48c43434a9c4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

