### PR TITLE
Keep locked groups under regrouping, ungrouping and Delete

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1728,6 +1728,8 @@ export default function Page() {
   const deleteSelected = useCallback(() => {
     if (selectedIds.length === 0) return;
     const ids = new Set(selectedIds);
+    /* nothing deletable when every selected part sits in a locked group: no snapshot, keep the selection */
+    if (groupsRef.current.every((g) => g.locked || !g.items.some((it) => ids.has(it.id)))) return;
     snapshot();
     setGroups((prev) =>
       prev
@@ -1947,6 +1949,8 @@ export default function Page() {
   const groupSelected = useCallback(() => {
     const ids = new Set(selectedIds);
     if (ids.size < 2) return;
+    /* regrouping would carry a locked group's parts into an unlocked group */
+    if (groupsRef.current.some((g) => g.locked && g.items.some((it) => ids.has(it.id)))) return;
     const rects = new Map(itemRects().map((r) => [r.id, r]));
     const picked: Item[] = [];
     let top = -1;
@@ -1995,7 +1999,8 @@ export default function Page() {
   /** Split a free group back into single runs at their current positions, in the same layer slot. */
   const ungroupSelected = useCallback(() => {
     const g = selectedGroup;
-    if (!g) return;
+    /* ungrouping would replace a locked group with unlocked single runs */
+    if (!g || g.locked) return;
     snapshot();
     const singles: Group[] = explodeGroup(g, widthsRef.current).map((run) => ({ ...run, id: uid() }));
     for (const sg of singles) instantRef.current.add(sg.id);

--- a/components/Layers.tsx
+++ b/components/Layers.tsx
@@ -111,7 +111,8 @@ function Row({
           <button
             onClick={onLock}
             title={t(locked ? "unlock" : "lock", lang)}
-            aria-pressed={locked}
+            aria-label={t(locked ? "unlock" : "lock", lang)}
+            aria-pressed={!!locked}
             className="m3-press"
             style={{ width: 28, height: 28, borderRadius: 14, border: "none", background: "transparent", color: locked ? (on ? p.onSecondaryContainer : p.primary) : p.outline, cursor: "pointer", padding: 0, display: "grid", placeItems: "center", flex: "0 0 auto" }}
           >


### PR DESCRIPTION
## What and why

Follows #130. Ctrl+G can no longer carry a locked group's parts into an unlocked group, and Ctrl+Shift+G no longer replaces a locked group with unlocked single runs. Delete on a selection that sits entirely inside locked groups is a full no-op: it no longer pushes an undo snapshot and it keeps the selection. The lock button in the Layers panel also carries a localized aria-label now, and its aria-pressed is always rendered by coercing the optional lock to a boolean.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] New or changed UI strings and prompt text exist in Japanese, English, Chinese and Korean
- [x] Tried it in the editor (and on a phone, if the change touches the phone editor)

## Screenshots

N/A — no visual change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents locked groups from being altered by regrouping, ungrouping, or delete operations.

- Delete on a selection fully inside locked groups is now a no-op: it no longer snapshots or changes the selection.
- Ctrl+G aborts when any selected item belongs to a locked group.
- Ctrl+Shift+G aborts when the selected group is locked.
- The Layers panel lock button now has a localized `aria-label` and its `aria-pressed` is always a boolean.

<sup>Written for commit 470fca46d59d0aaaf11fd23e2ee552b704ea784c. Summary will update on new commits.</sup>

<a href="https://www.cubic.dev/pr/lnkiai/m3e-canvas/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->