### PR TITLE
Fix preview modal focus and camera lifecycle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -161,12 +161,6 @@ input.m3-number {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-rail-motion] *,
-  [data-rail-motion] [data-wide-rail],
-  [data-rail-motion] [data-wide-rail] *,
-  [data-rail-motion] .m3-rail-hit {
-    transition: none !important;
-  }
   .m3-press,
   .m3-tile {
     transition: none;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -458,6 +458,8 @@ export default function Page() {
   widthsRef.current = widths;
   const viewRef = useRef(view);
   viewRef.current = view;
+  const previewIdRef = useRef(previewId);
+  previewIdRef.current = previewId;
   const leftOpenRef = useRef(leftOpen);
   leftOpenRef.current = leftOpen;
   const leftWRef = useRef(leftW);
@@ -595,8 +597,12 @@ export default function Page() {
   /** Puts a stored or opened document into the editor. Fields a partial document
    *  leaves out keep their current value, or go back to the default when `reset`. */
   const applyDoc = (doc: Partial<Doc>, reset: boolean) => {
-    setPreviewId(null);
-    viewBeforePreview.current = null;
+    // A document can arrive during the opening glide, before previewId is set.
+    // Keep that pending preview's return view until it actually opens and closes.
+    if (previewIdRef.current !== null) {
+      setPreviewId(null);
+      viewBeforePreview.current = null;
+    }
     const frames = Array.isArray(doc.frames) ? doc.frames : framesRef.current;
     if (Array.isArray(doc.groups)) setGroups(migrateGroups(doc.groups, frames));
     if (Array.isArray(doc.frames)) setFrames(doc.frames);

--- a/components/Preview.test.tsx
+++ b/components/Preview.test.tsx
@@ -92,10 +92,9 @@ describe("preview screen modal lifecycle", () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it.each(["peek", "exiting"])("keeps the %s screen inert and free of modal side effects", (kind) => {
-    const element = screenElement(kind === "peek");
-    if (kind === "peek") expect(element.props.active).toBe(false);
-    else hooks.present = false;
+  it("keeps the peek screen inert and free of modal side effects", () => {
+    const element = screenElement(true);
+    expect(element.props.active).toBe(false);
     const tree = renderScreen(element);
     attach(tree);
     const cleanup = runEffects();
@@ -108,7 +107,7 @@ describe("preview screen modal lifecycle", () => {
     expect(previous.focus).not.toHaveBeenCalled();
   });
 
-  it("focuses and registers keyboard handling only while the screen is active", () => {
+  it("focuses and registers keyboard handling while the screen is active", () => {
     const element = screenElement();
     const tree = renderScreen(element);
     attach(tree);
@@ -116,11 +115,32 @@ describe("preview screen modal lifecycle", () => {
     expect(tree.props).toMatchObject({ inert: false, role: "dialog", "aria-modal": true });
     expect(toggle.focus).toHaveBeenCalledOnce();
     expect(addEventListener).toHaveBeenCalledWith("keydown", expect.any(Function), true);
+    cleanup();
+    expect(removeEventListener).toHaveBeenCalledWith("keydown", addEventListener.mock.calls[0][1], true);
+  });
+
+  it("deactivates a mounted modal without reclaiming focus when it exits", () => {
+    const element = screenElement();
+    attach(renderScreen(element));
+    const cleanup = runEffects();
+    expect(toggle.focus).toHaveBeenCalledOnce();
+    expect(addEventListener).toHaveBeenCalledWith("keydown", expect.any(Function), true);
+    const listener = addEventListener.mock.calls[0][1];
+    vi.clearAllMocks();
+
     hooks.present = false;
-    renderScreen(element);
+    const exiting = renderScreen(element);
+    expect(exiting.props).toMatchObject({ inert: true, "aria-hidden": true });
+    expect(exiting.props.role).toBeUndefined();
+    expect(exiting.props["aria-modal"]).toBeUndefined();
     cleanup();
     expect(previous.focus).not.toHaveBeenCalled();
-    expect(removeEventListener).toHaveBeenCalledWith("keydown", addEventListener.mock.calls[0][1], true);
+    expect(removeEventListener).toHaveBeenCalledWith("keydown", listener, true);
+    const cleanupExiting = runEffects();
+    expect(toggle.focus).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
+    cleanupExiting();
+    expect(previous.focus).not.toHaveBeenCalled();
   });
 
   it.each(["connected", "inert", "disconnected"])("restores a %s previous target only when safe on modal dismissal", (status) => {

--- a/components/Preview.test.tsx
+++ b/components/Preview.test.tsx
@@ -1,0 +1,136 @@
+import { isValidElement, type ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PALETTES, type Doc } from "../lib/tokens";
+import { Preview } from "./Preview";
+
+const hooks = vi.hoisted(() => ({
+  refs: [] as { current: unknown }[],
+  cursor: 0,
+  effects: [] as (() => void | (() => void))[],
+  present: true,
+  peek: false,
+}));
+vi.mock("react", async (original) => ({
+  ...await original<typeof import("react")>(),
+  useState: (initial: unknown) => [hooks.peek && initial === null ? { frameId: "next", t: "slideLeft" } : typeof initial === "function" ? initial() : initial, vi.fn()],
+  useRef: (current: unknown) => hooks.refs[hooks.cursor++] ?? (hooks.refs[hooks.cursor - 1] = { current }),
+  useEffect: (effect: () => void | (() => void)) => { hooks.effects.push(effect); },
+  useMemo: (value: () => unknown) => value(),
+  useCallback: (callback: unknown) => callback,
+}));
+vi.mock("motion/react", () => ({
+  AnimatePresence: "presence",
+  motion: { div: "div", button: "button" },
+  useReducedMotion: () => false,
+  useIsPresent: () => hooks.present,
+  useMotionValue: (value: number) => ({ get: () => value }),
+  useTransform: () => 0,
+}));
+vi.mock("@/lib/tokens", () => import("../lib/tokens"));
+vi.mock("@/lib/rail", () => import("../lib/rail"));
+vi.mock("@/lib/railView", () => import("../lib/railView"));
+vi.mock("@/lib/i18n", async () => ({ ...await import("../lib/i18n"), useLang: () => "en" }));
+vi.mock("./M3Node", () => ({ M3Node: "node", Icon: "icon" }));
+vi.mock("./ui", () => ({ IconBtn: "button" }));
+
+const doc: Doc = {
+  frame: "phone", paletteKey: "purple", title: "", brief: "",
+  frames: [{ id: "first", name: "First", x: 0, y: 0, w: 1280, h: 800 }, { id: "next", name: "Next", x: 1400, y: 0, w: 1280, h: 800 }],
+  groups: [0, 1400].map((x, i) => ({
+    id: `group-${i}`, x, y: 0, axis: "y",
+    items: [{ id: `rail-${i}`, kind: "navRail", label: "", icon: "menu", variant: "filled", railExpanded: true, railModal: true }],
+  })),
+};
+type Element = ReactElement<Record<string, unknown>>;
+function elements(node: unknown): Element[] {
+  if (Array.isArray(node)) return node.flatMap(elements);
+  if (!isValidElement<Record<string, unknown>>(node)) return [];
+  return [node, ...elements(node.props.children)];
+}
+
+// Like Loading.test.tsx, inspect the actual elements and effect callbacks without
+// a DOM runtime. Browser tests cover Motion's presence propagation and real focus.
+function screenElement(peek = false) {
+  hooks.peek = peek;
+  const tree = Preview({ doc, widths: {}, palette: PALETTES[0], startId: "first", onClose: vi.fn() });
+  const screens = elements(tree).filter((element) => typeof element.type === "function" && "frame" in element.props);
+  hooks.peek = false;
+  hooks.refs = [];
+  return screens[peek ? 1 : 0];
+}
+function renderScreen(element: Element) {
+  hooks.cursor = 0;
+  hooks.effects = [];
+  return (element.type as (props: Record<string, unknown>) => Element)(element.props);
+}
+function runEffects() {
+  const cleanups = hooks.effects.map((effect) => effect());
+  return () => cleanups.forEach((cleanup) => cleanup?.());
+}
+
+describe("preview screen modal lifecycle", () => {
+  const previous = { isConnected: true, closest: vi.fn(), focus: vi.fn() };
+  const toggle = { closest: () => ({}), focus: vi.fn(() => { documentState.activeElement = toggle; }) };
+  const documentState = { activeElement: previous as typeof previous | typeof toggle };
+  const host = { querySelector: vi.fn(() => toggle), contains: (element: unknown) => element === toggle };
+  const addEventListener = vi.fn();
+  const removeEventListener = vi.fn();
+  const attach = (tree: Element) => { (tree.props.ref as { current: unknown }).current = host; };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hooks.refs = [];
+    hooks.cursor = 0;
+    hooks.effects = [];
+    hooks.present = true;
+    hooks.peek = false;
+    previous.isConnected = true;
+    previous.closest.mockReturnValue(null);
+    documentState.activeElement = previous;
+    vi.stubGlobal("document", documentState);
+    vi.stubGlobal("window", { addEventListener, removeEventListener });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it.each(["peek", "exiting"])("keeps the %s screen inert and free of modal side effects", (kind) => {
+    const element = screenElement(kind === "peek");
+    if (kind === "peek") expect(element.props.active).toBe(false);
+    else hooks.present = false;
+    const tree = renderScreen(element);
+    attach(tree);
+    const cleanup = runEffects();
+    expect(tree.props).toMatchObject({ inert: true, "aria-hidden": true });
+    expect(tree.props.role).toBeUndefined();
+    expect(tree.props["aria-modal"]).toBeUndefined();
+    expect(toggle.focus).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
+    cleanup();
+    expect(previous.focus).not.toHaveBeenCalled();
+  });
+
+  it("focuses and registers keyboard handling only while the screen is active", () => {
+    const element = screenElement();
+    const tree = renderScreen(element);
+    attach(tree);
+    const cleanup = runEffects();
+    expect(tree.props).toMatchObject({ inert: false, role: "dialog", "aria-modal": true });
+    expect(toggle.focus).toHaveBeenCalledOnce();
+    expect(addEventListener).toHaveBeenCalledWith("keydown", expect.any(Function), true);
+    hooks.present = false;
+    renderScreen(element);
+    cleanup();
+    expect(previous.focus).not.toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalledWith("keydown", addEventListener.mock.calls[0][1], true);
+  });
+
+  it.each(["connected", "inert", "disconnected"])("restores a %s previous target only when safe on modal dismissal", (status) => {
+    const element = screenElement();
+    attach(renderScreen(element));
+    const cleanup = runEffects();
+    previous.isConnected = status !== "disconnected";
+    previous.closest.mockReturnValue(status === "inert" ? {} : null);
+    renderScreen({ ...element, props: { ...element.props, groups: [] } });
+    cleanup();
+    expect(previous.focus).toHaveBeenCalledTimes(status === "connected" ? 1 : 0);
+  });
+});

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Item } from "@/lib/tokens";
-import { AnimatePresence, animate, motion, useMotionValue, useTransform, useReducedMotion } from "motion/react";
+import { AnimatePresence, animate, motion, useMotionValue, useTransform, useReducedMotion, useIsPresent } from "motion/react";
 import type { TargetAndTransition, Variants } from "motion/react";
 import {
   Action,
@@ -356,6 +356,7 @@ function Tappable({
 const ellipsisText: React.CSSProperties = { overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" };
 
 function Screen({
+  active = true,
   frame,
   groups,
   widths,
@@ -366,6 +367,7 @@ function Screen({
   values,
   onValue,
 }: {
+  active?: boolean;
   frame: Frame;
   groups: Group[];
   widths: Record<string, number>;
@@ -383,12 +385,17 @@ function Screen({
   const [railMotion, setRailMotion] = useState<(ReturnType<typeof railMotionTargets> & { animate: boolean }) | null>(null);
   const lang = useLang();
   const reducedMotion = useReducedMotion();
+  const isPresent = useIsPresent();
+  const interactive = active && isPresent;
+  const interactiveRef = useRef(interactive);
+  interactiveRef.current = interactive;
   const screenRef = useRef<HTMLDivElement>(null);
   const shownGroups = useMemo(() => Object.entries(railStates).reduce(
     (current, [id, railExpanded]) => updateRail(current, [frame], widths, id, { railExpanded }), constrainModalRails(groups),
   ), [groups, frame, widths, railStates]);
   const modalIds = new Set(shownGroups.flatMap((g) => { const rail = modalRailOf(g); return rail ? [rail.id] : []; }));
   const hasModal = modalIds.size > 0;
+  const modalActive = interactive && hasModal;
   const changeRail = (id: string, railExpanded: boolean, animate: boolean) => {
     const next = updateRail(shownGroups, [frame], widths, id, { railExpanded });
     setRailMotion({ ...railMotionTargets(shownGroups, next, widths, id), animate: animate && !reducedMotion });
@@ -419,18 +426,19 @@ function Screen({
   }, [railMotion]);
   useEffect(() => { setRailMotion(null); }, [groups, frame, widths]);
   useEffect(() => {
-    if (!hasModal) return;
+    if (!modalActive) return;
     const previous = document.activeElement as HTMLElement | null;
     screenRef.current?.querySelector<HTMLButtonElement>(`[data-rail-modal] [data-rail-toggle]`)?.focus();
-    return () => { if (previous?.isConnected) previous.focus(); };
-  }, [hasModal]);
+    // An exiting screen must not take focus back from its replacement.
+    return () => { if (interactiveRef.current && previous?.isConnected && !previous.closest("[inert]")) previous.focus(); };
+  }, [modalActive]);
   useEffect(() => {
-    if (hasModal && !document.activeElement?.closest("[data-rail-modal]")) {
+    if (modalActive && (!screenRef.current?.contains(document.activeElement) || !document.activeElement?.closest("[data-rail-modal]"))) {
       screenRef.current?.querySelector<HTMLButtonElement>("[data-rail-modal] [data-rail-toggle]")?.focus();
     }
-  }, [shownGroups, hasModal]);
+  }, [shownGroups, modalActive]);
   useEffect(() => {
-    if (!hasModal) return;
+    if (!modalActive) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Tab") {
         e.stopImmediatePropagation();
@@ -454,10 +462,12 @@ function Screen({
   return (
     <div
       ref={screenRef}
+      inert={!interactive}
+      aria-hidden={!interactive || undefined}
       data-rail-motion={railMotion?.animate ? "true" : undefined}
-      role={hasModal ? "dialog" : undefined}
-      aria-modal={hasModal ? true : undefined}
-      aria-label={hasModal ? t("railState", lang) : undefined}
+      role={modalActive ? "dialog" : undefined}
+      aria-modal={modalActive ? true : undefined}
+      aria-label={modalActive ? t("railState", lang) : undefined}
       onPointerDown={(e) => { if (hasModal) e.stopPropagation(); }}
       style={{ position: "absolute", inset: 0, background: p[frame.bg ?? "surface"], overflow: "hidden" }}
     >
@@ -975,7 +985,7 @@ export function Preview({
                   pointerEvents: "none",
                 }}
               >
-                <Screen frame={peekFrame} groups={peekGroups} {...screenProps} />
+                <Screen active={false} frame={peekFrame} groups={peekGroups} {...screenProps} />
               </motion.div>
             )}
           </motion.div>


### PR DESCRIPTION
## What and why

Follow up on the three non-blocking items requested in [the owner's #291 review](https://github.com/lnkiai/m3e-canvas/pull/291#issuecomment-5565129956). Based on current main at 652140a; all three were still present and no open PR covered them when checked.

- Restrict modal focus and keyboard effects to the current, present `Screen`. Peek screens are explicitly inactive; exiting screens use Motion's presence state. Both remain visually rendered but are inert, hidden from accessibility, and do not claim modal-dialog semantics. An exiting screen's cleanup cannot restore focus over the new screen.
- Preserve `viewBeforePreview` when a document replacement or undo arrives during the opening camera glide, before preview has actually opened. Already-open previews still close and discard their transient state on replacement. Read the current preview ID through a ref because the undo and share-link handlers retain older closures.
- Remove the unreachable reduced-motion rail CSS block. The existing reduced-motion handling and immediate geometry-update path remain in place.

The owner's locked-group and duplication fixes are preserved. No changes to progress rendering, phone-editor controls, document format, translations, or dependencies.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (594 tests, including 6 new modal lifecycle regressions)
- [x] `npm run build` passes
- [x] No new or changed UI strings or prompt text
- [x] Tried the production build in the desktop editor and preview

Production-browser checks:

- Modal A → modal B: during the transition A is inert and only B claims the dialog/focus. Escape closes B's rail without closing preview; focus remains in B after A unmounts.
- Modal → plain screen: the exiting modal cannot reclaim focus.
- Canceled peek into a screen with an authored expanded modal: target remains inert and hidden, with no modal focus or dialog claim. A committed swipe activates and focuses it only after committing.
- Share import and full-document undo during the 340ms opening glide: closing preview restores exactly the original camera position and scale.
- Import after preview is fully open: old preview closes; reopening and closing restores the new document's view.
- Emulated reduced motion: pointer toggle immediately reaches 96px with no animated motion marker, and temporary transition-scoping attributes clear.

Unit tests use the existing lightweight hook/element testing approach; real Motion presence propagation and browser event/focus behavior were checked in the production browser. Swipes were exercised with synthetic pointer input, not a physical touch device.

## Screenshots

Behavior-only lifecycle fixes; the visual rail design is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview modal focus and camera lifecycle follow-ups from review #291. Peek and exiting screens stay visually rendered but are now inert, hidden from accessibility, and don't claim modal-dialog semantics.

- Only the active, present screen receives focus and keyboard handling; an exiting screen can't restore focus to itself over the new screen.
- Preserves `viewBeforePreview` when a document replacement or undo arrives during the opening glide; already-open previews still close and discard transient state on replacement.
- Removes an unreachable reduced-motion rail CSS block; existing reduced-motion handling is unchanged.

<sup>Written for commit cf06e257045b2acc4997193afc9f71c0023cdcd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

