### PR TITLE
Add Arabic as a fifth UI language, right to left

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] `npm run typecheck` passes
 - [ ] `npm test` passes
 - [ ] `npm run build` passes
-- [ ] New or changed UI strings and prompt text exist in Japanese, English, Chinese and Korean
+- [ ] New or changed UI strings exist in Japanese, English, Chinese, Korean and Arabic; prompt text in the first four
 - [ ] Tried it in the editor (and on a phone, if the change touches the phone editor)
 
 ## Screenshots

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Node 22.12 or newer is required (the test suite needs it); CI uses Node 22. The 
 | Area | Files |
 |---|---|
 | Part definitions, sizes, corners, theme | `lib/tokens.ts` |
-| UI strings and part defaults (ja / en / zh / ko) | `lib/i18n.ts` |
+| UI strings and part defaults (ja / en / zh / ko / ar) | `lib/i18n.ts` |
 | Drawing a part | `components/M3Node.tsx` |
 | Editing a part (desktop / phone) | `components/Inspector.tsx`, `components/Mobile.tsx` |
 | Tap-through preview | `components/Preview.tsx` |
@@ -43,15 +43,17 @@ Node 22.12 or newer is required (the test suite needs it); CI uses Node 22. The 
 A new kind touches all of these; the existing kinds are the reference:
 
 1. `Kind`, `KIND_SPEC`, `KIND_ORDER` and, if needed, `sizeOf` / `baseRadii` / `iconSlotsOf` in `lib/tokens.ts`
-2. `KIND_TEXT` for all four languages in `lib/i18n.ts`
+2. `KIND_TEXT` for all five languages in `lib/i18n.ts`
 3. Rendering in `components/M3Node.tsx` (and `MEASURED` / `NO_BOX` when it applies)
 4. The item sentence in `itemJa`, `itemEn`, `itemZh`, `itemKo` and a `STYLE_NOTES` entry per language in `lib/prompt.ts`
 5. Any special editor in `components/Inspector.tsx`; tap targets in `components/Preview.tsx` if it is tappable
 
 ## Conventions
 
-- Code comments are in English. UI strings and prompt text exist in Japanese,
-  English, Chinese and Korean; a string added in one language must be added in all four.
+- Code comments are in English. UI strings exist in Japanese, English, Chinese,
+  Korean and Arabic; a string added in one language must be added in all five.
+  Prompt text exists in the first four — an Arabic editor writes its prompt in
+  English, the language coding agents read best.
 - Use the standard Material 3 Expressive values (sizes, corners, tokens) and name
   them the way Material does. When in doubt, link the Material page in your PR.
 - Keep the editor chrome and the parts on separate paths: parts are drawn from the
@@ -73,7 +75,7 @@ A new kind touches all of these; the existing kinds are the reference:
 - バグ報告や小さな修正は Issue または PR を直接どうぞ。
 - 新しい部品やパネル、プロンプトの文言など大きめの変更は、先に Issue で相談してください。
 - 質問やアイデアは Discussions へ。
-- コードのコメントは英語で書きます。UI の文言とプロンプト文は日本語・英語・中国語・韓国語の 4 言語すべてに追加してください。
+- コードのコメントは英語で書きます。UI の文言は日本語・英語・中国語・韓国語・アラビア語の 5 言語すべてに、プロンプト文は前の 4 言語に追加してください（アラビア語のエディタは英語のプロンプトを書きます）。
 - PR の前に `npm run typecheck`、`npm test`、`npm run build` を通してください。CI でも同じものが走ります。
 - 貢献したコードは MIT ライセンスで公開されます。
 
@@ -82,7 +84,7 @@ A new kind touches all of these; the existing kinds are the reference:
 - Bug 报告和小修改可以直接提 Issue 或 PR。
 - 新组件、新面板、提示词措辞等较大的改动，请先开 Issue 讨论。
 - 提问和想法请到 Discussions。
-- 代码注释用英文。UI 文字和提示词需同时提供日文、英文、中文、韩文四种语言。
+- 代码注释用英文。UI 文字需同时提供日文、英文、中文、韩文、阿拉伯文五种语言；提示词提供前四种（阿拉伯文编辑器生成英文提示词）。
 - 提交 PR 前请运行 `npm run typecheck`、`npm test` 和 `npm run build`，CI 会执行同样的检查。
 - 贡献的代码以 MIT 许可证发布。
 
@@ -91,6 +93,6 @@ A new kind touches all of these; the existing kinds are the reference:
 - 버그 보고나 작은 수정은 Issue 또는 PR로 바로 보내 주세요.
 - 새 부품, 새 패널, 프롬프트 문구 등 비교적 큰 변경은 먼저 Issue에서 상의해 주세요.
 - 질문과 아이디어는 Discussions로.
-- 코드 주석은 영어로 씁니다. UI 문구와 프롬프트 문장은 일본어·영어·중국어·한국어 네 언어 모두에 추가해 주세요.
+- 코드 주석은 영어로 씁니다. UI 문구는 일본어·영어·중국어·한국어·아랍어 다섯 언어 모두에, 프롬프트 문장은 앞의 네 언어에 추가해 주세요(아랍어 편집기는 영어 프롬프트를 씁니다).
 - PR 전에 `npm run typecheck`, `npm test`, `npm run build`를 통과시켜 주세요. CI에서도 같은 검사가 실행됩니다.
 - 기여한 코드는 MIT 라이선스로 공개됩니다.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,7 +102,7 @@ import { MotionPanel, ShapePanel, TypePanel } from "@/components/ThemePanel";
 import { ThemeContext, ensureFontLoaded, ensureLangFontLoaded } from "@/lib/theme";
 import { BottomSheet, MobileActionBar, MobileInspector, MobileLang, MobileSettings } from "@/components/Mobile";
 import { ConfirmDialog, IconBtn, Segmented } from "@/components/ui";
-import { Lang, LangContext, SEED_TEXT, getLang, isLang, setGlobalLang, t, translateDefaultFrameName, translateDefaultText } from "@/lib/i18n";
+import { Lang, LangContext, SEED_TEXT, getLang, isLang, isRtl, setGlobalLang, t, translateDefaultFrameName, translateDefaultText } from "@/lib/i18n";
 
 /** the screens while a model drafts: primary, tertiary and primary container, drifting */
 const DRAFT_GRADIENT = (p: Palette) => `linear-gradient(120deg, ${p.primaryContainer}, ${p.tertiaryContainer}, ${p.primary}, ${p.secondaryContainer}, ${p.primaryContainer})`;
@@ -665,9 +665,16 @@ export default function Page() {
         }
       } else {
         const nl = (navigator.language ?? "").toLowerCase();
-        initialLang = nl.startsWith("zh") ? "zh" : nl.startsWith("ko") ? "ko" : nl.startsWith("ja") ? "ja" : "en";
+        initialLang = nl.startsWith("ar") ? "ar" : nl.startsWith("zh") ? "zh" : nl.startsWith("ko") ? "ko" : nl.startsWith("ja") ? "ja" : "en";
         setLang(initialLang);
         queueMicrotask(() => fitRef.current());
+      }
+      /* ?lang= names the language outright, for a link that must open in one
+       * language whatever the browser or the last visit says */
+      const asked = new URLSearchParams(location.search).get("lang");
+      if (isLang(asked) && asked !== initialLang) {
+        initialLang = asked;
+        setLang(asked);
       }
       setGlobalLang(initialLang);
       initialLangRef.current = initialLang;
@@ -682,6 +689,8 @@ export default function Page() {
 
   useEffect(() => {
     document.documentElement.lang = lang;
+    /* a right-to-left language mirrors the editor: panels, menus and text all follow */
+    document.documentElement.dir = isRtl(lang) ? "rtl" : "ltr";
     /* the editor's own text and the parts both pick up the language's Noto face */
     document.body.style.fontFamily = uiFontFamily(lang);
     ensureLangFontLoaded(lang, () => setWidths({}));

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -688,7 +688,7 @@ export function Inspector({
           >
             <Icon name={grouped ? "group_work" : "select_all"} size={20} />
             <span style={{ fontSize: 14, fontWeight: 600, flex: 1, minWidth: 0 }}>
-              {grouped ? t("group", lang) : lang === "en" ? `${multi} ${t("selectedParts", lang)}` : `${multi}${t("selectedParts", lang)}`}
+              {grouped ? t("group", lang) : lang === "en" || lang === "ar" ? `${multi} ${t("selectedParts", lang)}` : `${multi}${t("selectedParts", lang)}`}
             </span>
             <IconBtn icon="delete" p={p} danger onClick={onDelete} title={t("deleteSelection", lang)} size={32} />
           </div>

--- a/components/PartsPalette.tsx
+++ b/components/PartsPalette.tsx
@@ -10,6 +10,7 @@ const CATEGORY_TEXT = {
   ja: { actions: "操作", navigation: "ナビゲーション", containment: "コンテナ", inputs: "入力", content: "コンテンツ", progress: "進捗" },
   zh: { actions: "操作", navigation: "导航", containment: "容器", inputs: "输入", content: "内容", progress: "进度" },
   ko: { actions: "동작", navigation: "내비게이션", containment: "컨테이너", inputs: "입력", content: "콘텐츠", progress: "진행 상태" },
+  ar: { actions: "الإجراءات", navigation: "التنقل", containment: "الحاويات", inputs: "الإدخال", content: "المحتوى", progress: "التقدّم" },
 } satisfies Record<string, Record<Category, string>>;
 
 export function PartsPalette({

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -141,7 +141,7 @@ function parseJsonObject(text: string): Record<string, unknown> {
 
 /* ---------- actions ---------- */
 
-const LANG_NAME: Record<Lang, string> = { ja: "Japanese", en: "English", zh: "Simplified Chinese", ko: "Korean" };
+const LANG_NAME: Record<Lang, string> = { ja: "Japanese", en: "English", zh: "Simplified Chinese", ko: "Korean", ar: "Arabic" };
 
 const hasText = (v?: string | null) => !!v && v.trim().length > 0;
 

--- a/lib/i18n.parity.test.ts
+++ b/lib/i18n.parity.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
-  COLOR_TOKEN_TEXT, FAB_MENU_TABS, KIND_TEXT, KO, LANGS, NAV_TABS, SEED_TEXT,
-  SWIPE_TEXT, TAB_LABELS, TRANSITION_TEXT, UI, t, type UIKey,
+  AR, COLOR_TOKEN_TEXT, FAB_MENU_TABS, KIND_TEXT, KO, LANGS, NAV_TABS, SEED_TEXT,
+  SWIPE_TEXT, TAB_LABELS, TRANSITION_TEXT, UI, t, type Lang, type UIKey,
 } from "./i18n";
 import { KIND_ORDER, LANG_FONT, SWIPE_DIRS, TRANSITIONS } from "./tokens";
 
 const ui: Record<UIKey, Record<string, string>> = UI;
-const ko: Record<UIKey, string> = KO;
+/* Languages added after the main table was written live in a table of their
+ * own, keyed the same way; the main table keeps only the first three. */
+const side: Partial<Record<Lang, Record<UIKey, string>>> = { ko: KO, ar: AR };
+const sideLangs = Object.keys(side) as Lang[];
 const keys = Object.keys(ui) as UIKey[];
 const languages = LANGS.map(({ key }) => key);
 const sortedKeys = (value: object) => Object.keys(value).sort();
@@ -39,23 +42,23 @@ describe("UI dictionary parity", () => {
   });
 
   it("offers each supported language exactly once with a nonblank display label", () => {
-    expect([...languages].sort()).toEqual(["en", "ja", "ko", "zh"]);
+    expect([...languages].sort()).toEqual(["ar", "en", "ja", "ko", "zh"]);
     for (const { key, label } of LANGS) nonemptyStrings(label, `LANGS.${key}`);
   });
 
-  it("gives Korean exactly the same keys as the main UI dictionary", () => {
+  it.each(sideLangs)("gives %s, kept in its own table, exactly the same keys as the main UI dictionary", (lang) => {
     expect(keys.length).toBeGreaterThan(0);
-    expect(sortedKeys(ko)).toEqual([...keys].sort());
+    expect(sortedKeys(side[lang]!)).toEqual([...keys].sort());
   });
 
-  it("gives every main UI key all and only the non-Korean languages", () => {
-    const expected = languages.filter((lang) => lang !== "ko").sort();
+  it("gives every main UI key all and only the languages kept in the main table", () => {
+    const expected = languages.filter((lang) => !sideLangs.includes(lang)).sort();
     for (const key of keys) expect(sortedKeys(ui[key]), key).toEqual(expected);
   });
 
   it.each(LANGS)("returns a nonblank translation for every UI key in $key", ({ key: lang }) => {
     for (const key of keys) {
-      const stored = lang === "ko" ? ko[key] : ui[key][lang];
+      const stored = side[lang]?.[key] ?? ui[key][lang];
       nonemptyStrings(stored, `UI.${key}.${lang}`);
       expect(t(key, lang), `${key}.${lang}`).toBe(stored);
     }
@@ -115,7 +118,7 @@ describe("LANG_FONT coverage", () => {
   });
 
   it.each([
-    ["ja", "JP"], ["zh", "SC"], ["ko", "KR"],
+    ["ja", "JP"], ["zh", "SC"], ["ko", "KR"], ["ar", "Arabic"],
   ] as const)("supplies the matching Noto font family and download query for %s", (lang, script) => {
     const font = LANG_FONT[lang];
     expect(font).not.toBeNull();

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -2,14 +2,17 @@
 
 import { createContext, useContext } from "react";
 
-export type Lang = "ja" | "en" | "zh" | "ko";
+export type Lang = "ja" | "en" | "zh" | "ko" | "ar";
 export const LANGS: { key: Lang; label: string }[] = [
   { key: "ja", label: "日本語" },
   { key: "en", label: "English" },
   { key: "zh", label: "中文" },
   { key: "ko", label: "한국어" },
+  { key: "ar", label: "العربية" },
 ];
-export const isLang = (v: unknown): v is Lang => v === "ja" || v === "en" || v === "zh" || v === "ko";
+export const isLang = (v: unknown): v is Lang => v === "ja" || v === "en" || v === "zh" || v === "ko" || v === "ar";
+/** the languages written right to left; the editor mirrors its layout for them */
+export const isRtl = (lang: Lang): boolean => lang === "ar";
 
 /* A module-level copy lets non-React helpers (item defaults, prompt text)
  * follow the language without threading it through every call. */
@@ -27,6 +30,7 @@ export const SEED_TEXT: Record<Lang, { favorite: string; share: string; inbox: s
   en: { favorite: "Favorite", share: "Share", inbox: "Inbox", starred: "Starred", archive: "Archive", supporting: "Supporting text", start: "Get started" },
   zh: { favorite: "收藏", share: "分享", inbox: "收件箱", starred: "已加星标", archive: "归档", supporting: "辅助文本", start: "开始" },
   ko: { favorite: "즐겨찾기", share: "공유", inbox: "받은편지함", starred: "별표 표시", archive: "보관함", supporting: "보조 텍스트", start: "시작하기" },
+  ar: { favorite: "المفضّلة", share: "مشاركة", inbox: "الوارد", starred: "المميّزة بنجمة", archive: "الأرشيف", supporting: "نص مساعد", start: "ابدأ" },
 };
 
 /** ponytail: matches defaults by text; add provenance if authored copies must be distinguished. */
@@ -64,6 +68,7 @@ export const COLOR_TOKEN_TEXT = {
   ja: { surface: "サーフェス", surfaceContainerLow: "コンテナ（低）", surfaceContainer: "コンテナ", surfaceContainerHigh: "コンテナ（高）", surfaceContainerHighest: "コンテナ（最高）", primaryContainer: "プライマリコンテナ", secondaryContainer: "セカンダリコンテナ", tertiaryContainer: "ターシャリコンテナ", primary: "プライマリ", inverseSurface: "反転サーフェス" },
   zh: { surface: "表面", surfaceContainerLow: "低层容器", surfaceContainer: "容器", surfaceContainerHigh: "高层容器", surfaceContainerHighest: "最高层容器", primaryContainer: "主色容器", secondaryContainer: "次色容器", tertiaryContainer: "第三色容器", primary: "主色", inverseSurface: "反色表面" },
   ko: { surface: "표면", surfaceContainerLow: "낮은 컨테이너", surfaceContainer: "컨테이너", surfaceContainerHigh: "높은 컨테이너", surfaceContainerHighest: "가장 높은 컨테이너", primaryContainer: "주 색상 컨테이너", secondaryContainer: "보조 색상 컨테이너", tertiaryContainer: "세 번째 색상 컨테이너", primary: "주 색상", inverseSurface: "반전 표면" },
+  ar: { surface: "السطح", surfaceContainerLow: "حاوية (منخفضة)", surfaceContainer: "حاوية", surfaceContainerHigh: "حاوية (مرتفعة)", surfaceContainerHighest: "حاوية (الأعلى)", primaryContainer: "حاوية أساسية", secondaryContainer: "حاوية ثانوية", tertiaryContainer: "حاوية ثالثية", primary: "أساسي", inverseSurface: "سطح معكوس" },
 };
 
 /** exported for the parity tests only; read strings through t() */
@@ -476,7 +481,72 @@ export const KO: Record<UIKey, string> = {
   aiErrorInsecure: "기본 URL은 https를 사용하거나 localhost를 가리켜야 합니다", aiErrorNetwork: "연결할 수 없습니다. URL, 네트워크 및 서버의 CORS 설정을 확인하세요",
 };
 
-export const t = (key: UIKey, lang: Lang = current): string => (lang === "ko" ? KO[key] : UI[key][lang]);
+/** exported for the parity tests only; read strings through t() */
+export const AR: Record<UIKey, string> = {
+  frameSize: "حجم الشاشة", phoneFrame: "هاتف", desktopFrame: "سطح المكتب", columnWidth: "عرض شاشة هاتف", cornerLeft: "الزوايا اليسرى", cornerRight: "الزوايا اليمنى", cornersEach: "كل زاوية على حدة", cornerTl: "أعلى اليسار", cornerTr: "أعلى اليمين", cornerBl: "أسفل اليسار", cornerBr: "أسفل اليمين",
+  filled: "معبّأ", tonal: "لوني", elevated: "مرتفع", outlined: "بإطار", standard: "قياسي", vibrant: "زاهٍ",
+  parts: "المكوّنات", layers: "الطبقات", edit: "تحرير", prompt: "البرومبت", closePanel: "إغلاق اللوحة",
+  search: "بحث", favorites: "المفضّلة", addFavorite: "إضافة إلى المفضّلة", removeFavorite: "إزالة من المفضّلة", clear: "مسح", language: "اللغة",
+  select: "تحديد (V)", hand: "اليد (H / Space)", blank: "لوحة فارغة", phone: "شاشات هاتف", addFrame: "إضافة شاشة", preview: "معاينة (P)",
+  zoomIn: "تكبير (+)", zoomOut: "تصغير (-)", fit: "ملاءمة الكل (0)", undo: "تراجع (Ctrl+Z)", redo: "إعادة (Ctrl+Shift+Z)",
+  clearAll: "مسح اللوحة", clearAllTitle: "هل تريد مسح اللوحة؟", clearAllBody: "ستُحذف كل الشاشات والمكوّنات. يمكن استعادتها بالتراجع (Ctrl+Z).",
+  screen: "الشاشة", screenName: "اسم الشاشة", name: "الاسم", background: "الخلفية", export: "تصدير", project: "المشروع",
+  saveProject: "حفظ المشروع", openProject: "فتح مشروع", replaceProjectTitle: "هل تريد فتح هذا المشروع؟",
+  replaceProject: "ستُستبدل اللوحة الحالية. التراجع (Ctrl+Z) يعيدها.",
+  askAi: "اطلب من الذكاء الاصطناعي",
+  askAiHint: "اكتب ما تريد صنعه ثم اضغط «ارسم بالذكاء الاصطناعي»: النموذج المحدّد في تبويب AI يرسم التصميم على اللوحة. أو انسخ التعليمات لوكيل ذكاء اصطناعي مثل Claude Code؛ افتح الرابط الذي يردّ به، أو احفظ JSON الذي يعطيه وحمّله من «فتح مشروع».",
+  askAiGenerate: "ارسم بالذكاء الاصطناعي", askAiGenerating: "جارٍ الرسم…",
+  askAiPasted: "الصقه في وكيل الذكاء الاصطناعي", askAiTitle: "اطلب تصميماً من الذكاء الاصطناعي", askAiCopyTitle: "تعليمات لوكيل ذكاء اصطناعي", askAiGenerateTitle: "يستعمل المفتاح الموجود في تبويب AI", aiSetup: "إعدادات AI", aiSetupHint: "أضف مفتاحاً لترسم هنا مباشرة", aiSetupTitle: "افتح تبويب AI",
+  draftKeep: "اعتماد هذا التصميم", draftUndo: "العودة إلى التصميم السابق",
+  askAiIdea: "ما الذي تريد بناءه (مثال: تطبيق لحفظ الوصفات والبحث فيها)", askAiIdeaFallback: "(اكتب هنا ما تريد بناءه)", askAiCopy: "نسخ التعليمات",
+  askAiText: "اصنع مخطّطاً في M3E Canvas. اقرأ أولاً {url} واتّبعه: ابنِ التصميم بصيغة JSON ثم أجب برابط مشاركة. إن لم تستطع تشغيل الشيفرة فأجب بـJSON داخل كتلة شيفرة (سيُحفظ في ملف ويُفتح). لا حاجة إلى التحقق.\n\nما الذي تريد بناءه: {idea}",
+  selectedTab: "اجعله المحدّد",
+  shareLinkCopy: "نسخ الرابط", shareLinkHint: "رابط يفتح هذا التصميم (بلا صور)",
+  invalidProject: "تعذّر فتح ملف المشروع.", readOnlyTitle: "يجري التحرير في تبويب آخر",
+  readOnlyBody: "هذه اللوحة قيد التحرير في تبويب آخر. أغلق ذلك التبويب ثم أعد تحميل هذه الصفحة للتحرير.",
+  reload: "إعادة التحميل",
+  copied: "تم النسخ", saveImage: "حفظ كصورة", saving: "جارٍ الحفظ…", previewFrom: "معاينة من هذه الشاشة",
+  duplicate: "تكرار", duplicateKey: "تكرار (Ctrl+D)", delete: "حذف (Delete)", deleteSelection: "حذف المحدّد",
+  text: "النص", label: "التسمية", bold: "غامق", action: "الإجراء", supporting: "نص مساعد", tabs: "العناصر", changeIcon: "تغيير الأيقونة",
+  options: "الخيارات", addOption: "إضافة خيار", removeOption: "حذف هذا الخيار", selectedOption: "اجعله القيمة الأولية (اضغط مرة أخرى لإلغائها)", image: "صورة", pickImage: "اختيار صورة", removeImage: "إزالة الصورة", imageUrl: "رابط الصورة", imageArea: "منطقة الصورة", autoWidth: "عرض النص", icon: "الأيقونة", noIcon: "بلا أيقونة", searchIcons: "بحث في الأيقونات",
+  style: "النمط", state: "الحالة", selected: "محدّد", handle: "مقبض (لوحة سفلية)", listSwitch: "مفتاح في النهاية", on: "مفعّل", container: "الحاوية", wavy: "متموّج", determinate: "محدّد المقدار",
+  railState: "حالة الشريط الجانبي", railCollapsed: "مطويّ", railExpanded: "موسّع",
+  railLegacy: "الشريط التقليدي · عرض 80dp", railUpgrade: "استخدام Expressive (96dp)",
+  railStandalone: "أخرج الشريط من المجموعة لتفعيل العرض المنبثق.",
+  railPresentation: "طريقة التوسيع", railStandard: "ضمن التخطيط", railModal: "طبقة منبثقة",
+  expandNavigation: "توسيع التنقل", collapseNavigation: "طيّ التنقل",
+  trackThickness: "سُمك المسار",
+  size: "الحجم", width: "العرض", height: "الارتفاع", fontSize: "حجم الخط", cornerRadius: "استدارة الزوايا", cornerTop: "الزوايا العلوية", cornerBottom: "الزوايا السفلية",
+  screenWidth: "عرض الشاشة", contentWidth: "هوامش جانبية 16dp", halfWidth: "نصف صف (عمودان)", screenHeight: "ارتفاع الشاشة", halfHeight: "نصف الشاشة",
+  tapTo: "النقر يفتح", none: "بلا", goBack: "رجوع", swipeTo: "السحب يفتح", toggle: "زر تبديل", toggleHint: "النقر يبدّل بين التشغيل والإيقاف",
+  thumbCheck: "أيقونة صحّ عند التشغيل", behavior: "السلوك", whenPressed: "عند الضغط…", whatItDoes: "ما يفعله هذا المكوّن…", removeLink: "إزالة الرابط",
+  group: "المجموعة", makeGroup: "تجميع", ungroup: "فكّ التجميع", selectedParts: "محدّدة", groupHint: "يحافظ على التراكب ويتحرك كطبقة واحدة",
+  iconBackground: "خلفية الأيقونة", noBackground: "بلا خلفية", normalState: "عادي", onState: "مفعّل", onStateHint: "النص والأيقونة والنمط عند التشغيل",
+  groupEditNote: "فكّ التجميع لتحرير المكوّنات داخله", openPanel: "فتح اللوحة", colors: "الألوان", templates: "لوحات الألوان", customColor: "مخصّص",
+  seedColor: "اللون الأساس", seedHint: "لون واحد يبني كامل نظام ألوان Material 3. الضبط الدقيق يغيّر أدواراً بعينها.",
+  useThis: "استخدامه", fineTune: "ضبط دقيق", dynamicColor: "لون ديناميكي",
+  dynamicOnHint: "هذه الألوان للمحرّر فقط؛ الهاتف يستعمل ألوان خلفيته.",
+  dynamicOffHint: "عند التفعيل يستعمل الهاتف ألوان خلفيته وتبقى هذه احتياطاً.", closeBtn: "إغلاق", screens: "اختيار الشاشة",
+  noLayers: "لا شيء على هذه الشاشة بعد", showParts: "إظهار المكوّنات داخلها", hideParts: "إخفاء المكوّنات داخلها", lock: "قفل", unlock: "فكّ القفل", lockedGroup: "هذه المجموعة مقفلة. فكّ قفلها من لوحة الطبقات أولاً",
+  brief: "ما هذا التطبيق…", appName: "اسم التطبيق", targetPlatform: "الهدف", targetAndroid: "بناؤه كتطبيق Android أصلي",
+  targetWeb: "بناؤه كتطبيق ويب يعمل في المتصفح", copyPrompt: "نسخ البرومبت", back: "رجوع", close: "إغلاق (Esc)", cancel: "إلغاء", ok: "موافق",
+  leading: "البداية", trailing: "النهاية", home: "الرئيسية", screenN: "الشاشة", copySuffix: " نسخة", mobileNote: "الميزات الكاملة في متصفح الحاسوب",
+  addButton: "إضافة زر", done: "تم", theme: "السمة", settings: "السمة والإعدادات", shape: "الشكل", typography: "الخط", motion: "الحركة",
+  brightness: "السطوع", light: "فاتح", dark: "داكن", contrast: "التباين", bothModes: "كلاهما", contrastStandard: "قياسي", contrastMedium: "متوسط", contrastHigh: "عالٍ",
+  shapeScale: "درجة استدارة الزوايا", shapeSquare: "مربّع", shapeRounded: "مستدير", shapeFull: "كامل الاستدارة",
+  shapeHint: "يغيّر الزوايا الافتراضية لكل المكوّنات دفعة واحدة. الاستدارة التي كتبتها على مكوّن بعينه تبقى كما هي.", fontFamily: "نوع الخط", emphasized: "مؤكَّد",
+  emphasizedHint: "العناوين والتسميات تستعمل أنماط M3 Expressive الأثقل.", motionScheme: "نظام الحركة", motionStandard: "قياسي", motionExpressive: "تعبيري",
+  motionHint: "التعبيري نابض مرن. يحرّك انتقالات المعاينة والبرومبت.", tryIt: "انقر للتجربة",
+  tidy: "ترتيب", tidyUndo: "التراجع عن الترتيب", tidyDone: "مرتّب أصلاً", placement: "موضع المحتوى عمودياً", placeTop: "من الأعلى", placeCenter: "في الوسط", placeBottom: "في الأسفل", placeSpread: "موزَّع", align: "محاذاة", alignHintOne: "يحاذي المكوّن مع محتوى الشاشة، داخل الهوامش وبعيداً عن الأشرطة.", alignHintMany: "يحاذي المكوّنات المحدّدة بعضها مع بعض. التوزيع المتساوي يثبّت الطرفين.", alignLeft: "محاذاة لليسار", alignCenterH: "توسيط أفقي", alignRight: "محاذاة لليمين", distributeH: "توزيع أفقي", alignTop: "محاذاة للأعلى", alignCenterV: "توسيط عمودي", alignBottom: "محاذاة للأسفل", distributeV: "توزيع عمودي", description: "الوصف", screenDescription: "الغرض من هذه الشاشة",
+  ai: "AI", promptReset: "العودة إلى البرومبت المولَّد", aiWriteShort: "كتابة بالذكاء الاصطناعي", aiWrite: "دع الذكاء الاصطناعي يكتبه", aiSettings: "إعدادات AI",
+  aiProvider: "المزوّد", aiBaseUrl: "العنوان الأساسي", aiModel: "معرّف النموذج", aiKey: "مفتاح API", aiGetKey: "الحصول على مفتاح",
+  aiKeyHint: "يُحفظ في هذا المتصفح فقط ويُرسل مباشرة إلى المزوّد.", aiRestore: "التبديل بين صياغة الذكاء الاصطناعي والأصل", aiApplied: "تم التطبيق",
+  aiSelectScreen: "اختر شاشة أولاً", aiNoKey: "أضف مفتاحاً في تبويب AI لاستعمال هذا", aiError: "فشل طلب الذكاء الاصطناعي",
+  aiErrorRefusal: "رفض النموذج الإجابة", aiErrorJson: "تعذّرت قراءة ردّ النموذج", aiErrorLong: "الردّ طويل فقُطع. جرّب شاشات أقل", aiErrorModel: "أدخل معرّف النموذج",
+  aiErrorInsecure: "يجب أن يستعمل العنوان الأساسي https أو يشير إلى localhost", aiErrorNetwork: "تعذّر الاتصال. تحقق من العنوان والشبكة وإعدادات CORS في الخادم",
+};
+
+export const t = (key: UIKey, lang: Lang = current): string => (lang === "ko" ? KO[key] : lang === "ar" ? AR[key] : UI[key][lang]);
 
 /* ---- part defaults and nouns ---- */
 
@@ -624,6 +694,41 @@ export const KIND_TEXT: Record<
     radio: { noun: "라디오 버튼", label: "옵션" },
     badge: { noun: "배지", label: "3" },
   },
+  ar: {
+    box: { noun: "صندوق" },
+    button: { noun: "زر", label: "زر" },
+    iconButton: { noun: "زر أيقونة" },
+    fab: { noun: "زر عائم (FAB)" },
+    extendedFab: { noun: "زر عائم موسّع", label: "إنشاء" },
+    chip: { noun: "شريحة", label: "شريحة" },
+    topAppBar: { noun: "شريط التطبيق العلوي", label: "العنوان" },
+    bottomNav: { noun: "شريط التنقل" },
+    navRail: { noun: "شريط التنقل الجانبي" },
+    searchBar: { noun: "شريط البحث", label: "بحث" },
+    card: { noun: "بطاقة", label: "عنوان البطاقة", supporting: "النص المساعد يُكتب هنا." },
+    listItem: { noun: "عنصر قائمة", label: "عنصر قائمة", supporting: "نص مساعد" },
+    dialog: { noun: "مربّع حوار", label: "تأكيد", supporting: "هل تريد المتابعة؟" },
+    snackbar: { noun: "شريط إشعار", label: "تم الحفظ", supporting: "تراجع" },
+    textField: { noun: "حقل نص", label: "التسمية" },
+    select: { noun: "قائمة منسدلة", label: "التسمية" },
+    switch: { noun: "مفتاح", label: "الإشعارات" },
+    checkbox: { noun: "خانة اختيار", label: "أوافق" },
+    slider: { noun: "شريط تمرير" },
+    text: { noun: "نص", label: "عنوان" },
+    image: { noun: "صورة" },
+    camera: { noun: "كاميرا" },
+    map: { noun: "خريطة" },
+    divider: { noun: "فاصل" },
+    loadingIndicator: { noun: "مؤشر تحميل" },
+    linearProgress: { noun: "مؤشر تقدّم خطّي" },
+    circularProgress: { noun: "مؤشر تقدّم دائري" },
+    splitButton: { noun: "زر مقسوم", label: "إرسال" },
+    fabMenu: { noun: "قائمة زر عائم" },
+    toolbar: { noun: "شريط أدوات" },
+    tabs: { noun: "تبويبات" },
+    radio: { noun: "زر اختيار", label: "خيار" },
+    badge: { noun: "شارة", label: "3" },
+  },
 };
 
 /** default labels of a tab row */
@@ -632,6 +737,7 @@ export const TAB_LABELS: Record<Lang, string[]> = {
   en: ["For you", "Following", "Trending", "New", "Saved"],
   zh: ["推荐", "关注", "热门", "最新", "已保存"],
   ko: ["추천", "팔로잉", "인기", "새 항목", "저장됨"],
+  ar: ["لك", "المتابَعون", "الرائج", "الجديد", "المحفوظ"],
 };
 
 /** default entries of a FAB menu */
@@ -641,6 +747,7 @@ export const SELECT_OPTIONS: Record<Lang, string[]> = {
   en: ["Option 1", "Option 2", "Option 3"],
   zh: ["选项 1", "选项 2", "选项 3"],
   ko: ["옵션 1", "옵션 2", "옵션 3"],
+  ar: ["الخيار 1", "الخيار 2", "الخيار 3"],
 };
 
 export const FAB_MENU_TABS: Record<Lang, { icon: string; label: string }[]> = {
@@ -672,6 +779,13 @@ export const FAB_MENU_TABS: Record<Lang, { icon: string; label: string }[]> = {
     { icon: "attach_file", label: "파일" },
     { icon: "event", label: "일정" },
   ],
+  ar: [
+    { icon: "edit", label: "ملاحظة" },
+    { icon: "photo_camera", label: "صورة" },
+    { icon: "mic", label: "صوت" },
+    { icon: "attach_file", label: "ملف" },
+    { icon: "event", label: "موعد" },
+  ],
 };
 
 export const NAV_TABS: Record<Lang, { icon: string; label: string }[]> = {
@@ -698,6 +812,12 @@ export const NAV_TABS: Record<Lang, { icon: string; label: string }[]> = {
     { icon: "search", label: "검색" },
     { icon: "favorite", label: "저장됨" },
     { icon: "settings", label: "설정" },
+  ],
+  ar: [
+    { icon: "home", label: "الرئيسية" },
+    { icon: "search", label: "بحث" },
+    { icon: "favorite", label: "المحفوظ" },
+    { icon: "settings", label: "الإعدادات" },
   ],
 };
 
@@ -738,6 +858,15 @@ export const TRANSITION_TEXT: Record<Lang, Record<string, string>> = {
     expand: "확대",
     none: "애니메이션 없음",
   },
+  ar: {
+    slide: "انزلاق من اليمين",
+    slideLeft: "انزلاق من اليسار",
+    slideUp: "انزلاق من الأسفل",
+    slideDown: "انزلاق من الأعلى",
+    fade: "تلاشٍ",
+    expand: "تمدّد",
+    none: "بلا حركة",
+  },
 };
 
 export const SWIPE_TEXT: Record<Lang, Record<string, string>> = {
@@ -745,4 +874,5 @@ export const SWIPE_TEXT: Record<Lang, Record<string, string>> = {
   en: { left: "swiping left", right: "swiping right", up: "swiping up", down: "swiping down" },
   zh: { left: "向左滑动", right: "向右滑动", up: "向上滑动", down: "向下滑动" },
   ko: { left: "왼쪽으로 스와이프", right: "오른쪽으로 스와이프", up: "위로 스와이프", down: "아래로 스와이프" },
+  ar: { left: "السحب إلى اليسار", right: "السحب إلى اليمين", up: "السحب إلى الأعلى", down: "السحب إلى الأسفل" },
 };

--- a/lib/prompt.test.ts
+++ b/lib/prompt.test.ts
@@ -4,17 +4,20 @@ import { Lang, setGlobalLang } from "./i18n";
 import { buildPrompt } from "./prompt";
 import { BACK_TARGET, DEFAULT_THEME, Doc, Item, Platform, defaultTabs, makeItem, paletteOf } from "./tokens";
 
-const LANGS: Lang[] = ["ja", "en", "zh", "ko"];
+/* The four languages the prompt is written in. Arabic is offered by the editor
+ * but has no prompt voice of its own: it writes English, checked below. */
+type PromptLang = Exclude<Lang, "ar">;
+const LANGS: PromptLang[] = ["ja", "en", "zh", "ko"];
 
 /* Section headings in the order buildPrompt must emit them. */
-const SECTIONS: Record<Lang, string[]> = {
+const SECTIONS: Record<PromptLang, string[]> = {
   ja: ["## カラー", "## 形・文字・動き", "## 画面構成", "## 振る舞いと画面遷移", "## 各部品のスタイル", "## 全体の指針"],
   en: ["## Colors", "## Shape, type and motion", "## Layout", "## Behavior and navigation", "## Component styles", "## General guidance"],
   zh: ["## 配色", "## 形状、字体与动效", "## 屏幕结构", "## 行为与屏幕跳转", "## 各组件的样式", "## 整体原则"],
   ko: ["## 색상", "## 모양, 글꼴 및 모션", "## 화면 구성", "## 동작 및 화면 전환", "## 부품별 스타일", "## 전체 지침"],
 };
 
-const PLATFORM_LINE: Record<Lang, Record<Platform, string>> = {
+const PLATFORM_LINE: Record<PromptLang, Record<Platform, string>> = {
   ja: { android: "実装先は Android（ネイティブアプリ）です。", web: "実装先は Web（ブラウザで動くアプリ）です。" },
   en: { android: "Build it for Android, as a native app.", web: "Build it for the web, as an app that runs in the browser." },
   zh: { android: "实现目标是 Android（原生应用）。", web: "实现目标是 Web（在浏览器中运行的应用）。" },
@@ -54,19 +57,29 @@ function build(lang: Lang, platform: Platform = "android", extraItems: Item[] = 
 const lines = (prompt: string) => prompt.split("\n");
 const headings = (prompt: string) => lines(prompt).filter((l) => l.startsWith("## "));
 /* bullet lines between the style heading and the closing guidance heading */
-function styleBullets(prompt: string, lang: Lang) {
+function styleBullets(prompt: string, lang: PromptLang) {
   const ls = lines(prompt);
   const style = ls.indexOf(SECTIONS[lang][4]);
   const general = ls.indexOf(SECTIONS[lang][5]);
   return ls.slice(style + 1, general).filter((l) => l.startsWith("- "));
 }
 
-const QUOTED: Record<Lang, { label: string; others: string[] }> = {
+const QUOTED: Record<PromptLang, { label: string; others: string[] }> = {
   ja: { label: "「Save」", others: ['"Save"', "“Save”"] },
   en: { label: '"Save"', others: ["「Save」", "“Save”"] },
   zh: { label: "“Save”", others: ["「Save」", '"Save"'] },
   ko: { label: '"Save"', others: ["「Save」", "“Save”"] },
 };
+
+describe("buildPrompt for the Arabic editor", () => {
+  afterEach(() => setGlobalLang("ja"));
+
+  it("writes the prompt in English, the language a coding agent reads best", () => {
+    const prompt = build("ar", "web");
+    expect(headings(prompt)).toEqual(SECTIONS.en);
+    expect(prompt).toContain(PLATFORM_LINE.en.web);
+  });
+});
 
 describe("progress track thickness", () => {
   afterEach(() => setGlobalLang("ja"));
@@ -240,7 +253,7 @@ describe("buildPrompt structure", () => {
 describe("buildPrompt for the camera, map and dropdown parts", () => {
   afterEach(() => setGlobalLang("ja"));
 
-  const NOUN: Record<Lang, [camera: string, map: string]> = {
+  const NOUN: Record<PromptLang, [camera: string, map: string]> = {
     ja: ["カメラプレビュー", "地図"],
     en: ["camera preview", "map"],
     zh: ["相机预览", "地图"],

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -31,12 +31,20 @@ import {
   progressThickness,
 } from "./tokens";
 
-const VARIANT_TEXT: Record<Lang, Record<Variant, string>> = {
+/** The prompt is read by a coding agent, and Arabic has no prompt voice of its
+ *  own yet: an Arabic editor writes its prompt in English, the language those
+ *  agents read best. */
+type PromptLang = Exclude<Lang, "ar">;
+const promptLang = (lang: Lang): PromptLang => (lang === "ar" ? "en" : lang);
+/** a table written in the four prompt languages, with Arabic reading the English */
+const withArabic = <T>(table: Record<PromptLang, T>): Record<Lang, T> => ({ ...table, ar: table.en });
+
+const VARIANT_TEXT: Record<Lang, Record<Variant, string>> = withArabic({
   ja: { filled: "塗りつぶし", tonal: "トーナル", elevated: "エレベーテッド", outlined: "アウトライン", text: "テキスト" },
   en: { filled: "filled", tonal: "tonal", elevated: "elevated", outlined: "outlined", text: "text" },
   zh: { filled: "填充", tonal: "色调", elevated: "浮起", outlined: "描边", text: "文字" },
   ko: { filled: "채움", tonal: "토널", elevated: "돌출", outlined: "윤곽선", text: "텍스트" },
-};
+});
 
 const hasText = (s?: string | null) => !!s && s.trim().length > 0;
 /** what sits at the top of a card: nothing, a picture, or the placeholder with its icon */
@@ -764,14 +772,14 @@ function describeNodes(lines: string[], nodes: LNode[], within: Rect | null, wid
   });
 }
 
-const RAIL_LEAD: Record<Lang, string> = { ja: "左端に", en: "Along the left edge: ", zh: "左缘：", ko: "왼쪽 가장자리에 " };
+const RAIL_LEAD: Record<Lang, string> = withArabic({ ja: "左端に", en: "Along the left edge: ", zh: "左缘：", ko: "왼쪽 가장자리에 " });
 
-const WIDE_RAIL_STYLE: Record<Lang, string> = {
+const WIDE_RAIL_STYLE: Record<Lang, string> = withArabic({
   ja: "M3 Expressive ナビゲーションレール: 折りたたみ時は幅 96dp、アイコンの下にラベル。展開時は幅 220dp、高さ 56dp の項目内でアイコンとラベルを横並びにし、間隔は 8dp。既存のトップアプリバーに合わせ、両モードの開閉状態すべてで背景は surfaceContainer。選択項目は secondaryContainer のピル型インジケータ、アイコンは onSecondaryContainer、ラベルは secondary を優先し、実際の背景（折りたたみ時は surfaceContainer、展開時は secondaryContainer）とのコントラストが 4.5:1 未満なら、それぞれ onSurface / onSecondaryContainer を使う。上部のメニューボタンで開閉する。非モーダル型は本文の横に配置し、モーダル型は展開時にスクリムとともに本文に重ね、背景操作を遮断する。スクリムのタップまたは Escape で閉じる。",
   en: "M3 Expressive navigation rail: 96dp wide when collapsed, with labels below icons. Expanded width is 220dp, with 56dp-high destinations and horizontal icon/label rows separated by 8dp. Match the existing top app bar with a surfaceContainer background in both modes, whether collapsed or expanded. The selected destination uses a secondaryContainer pill, onSecondaryContainer icon, and a label that prefers secondary. If its contrast against the actual background (surfaceContainer when collapsed, secondaryContainer when expanded) is below 4.5:1, use onSurface / onSecondaryContainer respectively. A top menu button toggles expansion. The non-modal variant sits beside the content; the modal variant overlays it with a scrim when expanded and blocks background interaction. Dismiss with a scrim tap or Escape.",
   zh: "M3 Expressive 侧边导航栏：折叠宽 96dp，标签位于图标下方。展开宽 220dp，项目高 56dp，图标与标签横向排列，间距 8dp。沿用现有顶部应用栏配色，两种模式在折叠与展开时均使用 surfaceContainer 背景。选中项用 secondaryContainer 胶囊指示器，图标为 onSecondaryContainer，文字优先使用 secondary；若与实际背景（折叠为 surfaceContainer，展开为 secondaryContainer）的对比度低于 4.5:1，则分别使用 onSurface / onSecondaryContainer。顶部菜单按钮切换展开与折叠。非模态型位于内容旁；模态型展开时带遮罩覆盖内容并阻止背景交互，点击遮罩或按 Escape 关闭。",
   ko: "M3 Expressive 내비게이션 레일: 접으면 너비 96dp, 아이콘 아래에 레이블을 배치한다. 펼치면 너비 220dp, 항목 높이 56dp, 아이콘과 레이블을 8dp 간격으로 가로 배치한다. 기존 상단 앱 바와 맞추어 두 모드의 접힌 상태와 펼친 상태 모두 surfaceContainer 배경을 사용한다. 선택 항목은 secondaryContainer 알약 표시기, onSecondaryContainer 아이콘, 레이블은 secondary를 우선 사용한다. 실제 배경(접힘: surfaceContainer, 펼침: secondaryContainer)과의 대비가 4.5:1 미만이면 각각 onSurface / onSecondaryContainer를 사용한다. 상단 메뉴 버튼으로 펼치기와 접기를 전환한다. 비모달은 콘텐츠 옆에 배치하고 모달은 펼칠 때 스크림과 함께 콘텐츠를 덮어 배경 조작을 차단한다. 스크림을 탭하거나 Escape를 누르면 닫힌다.",
-};
+});
 
 function describeScreen(lines: string[], groups: Group[], frameRect: Rect | null, widths: Record<string, number>, lang: Lang) {
   if (!groups.length) return;
@@ -834,7 +842,7 @@ function paletteLines(p: Palette): string[] {
 
 /** How each kind should look; only the kinds on the canvas are written out.
  *  `boxSheet` is the box note used when at least one box has its handle on. */
-const STYLE_NOTES: Record<Lang, Partial<Record<Kind | "boxSheet", string>>> = {
+const STYLE_NOTES: Record<Lang, Partial<Record<Kind | "boxSheet", string>>> = withArabic({
   ja: {
     button:
       "ボタン: 高さ 56dp のミディアムサイズで、角は完全な丸（ピル型）。塗りつぶしは primary、トーナルは secondaryContainer、アウトラインは outline の 1dp 枠。横に連結したボタングループは 3dp の隙間で並べ、隣り合う内側の角だけ 8dp に小さくし、外側の角は丸のままにする（M3 Expressive の Connected button group）。",
@@ -1015,18 +1023,18 @@ const STYLE_NOTES: Record<Lang, Partial<Record<Kind | "boxSheet", string>>> = {
     radio: "라디오 버튼: 20dp 원형. 선택 시 primary 테두리와 가운데 점, 미선택 시 onSurfaceVariant 테두리. 그룹에서 하나만 선택되며 레이블은 오른쪽 bodyLarge.",
     badge: "배지: 텍스트가 없으면 6dp 점, 있으면 높이 16dp 알약 모양. 배경 error, 텍스트 onError/labelSmall로 아이콘이나 항목 오른쪽 위에 겹쳐 둔다.",
   },
-};
+});
 
 /* ---------- theme: shape, type, motion ---------- */
 
-const FONT_NOTE: Record<Lang, (name: string) => string> = {
+const FONT_NOTE: Record<Lang, (name: string) => string> = withArabic({
   ja: (n) => `書体は ${n} を使う。`,
   en: (n) => `Use ${n} as the typeface.`,
   zh: (n) => `字体使用 ${n}。`,
   ko: (n) => `사용할 글꼴: ${n}.`,
-};
+});
 
-const THEME_NOTES: Record<Lang, { shape: Record<Theme["shape"], string>; emphasized: string; plainType: string; motion: Record<Theme["motion"], string> }> = {
+const THEME_NOTES: Record<Lang, { shape: Record<Theme["shape"], string>; emphasized: string; plainType: string; motion: Record<Theme["motion"], string> }> = withArabic({
   ja: {
     shape: {
       square: "角丸は控えめにする: M3 の shape スケールを全体に小さく取り（ボタン・チップは 8〜12dp、カードや画像は 8dp、ダイアログは 12dp 程度）、ピル型は使わない。",
@@ -1079,7 +1087,7 @@ const THEME_NOTES: Record<Lang, { shape: Record<Theme["shape"], string>; emphasi
       expressive: "모션은 MotionScheme.expressive()를 사용한다. 화면 전환과 상태 변화에 가볍게 튀는 스프링 효과를 적용한다.",
     },
   },
-};
+});
 
 function themeLines(th: Theme, lang: Lang): string[] {
   const n = THEME_NOTES[lang];
@@ -1090,7 +1098,7 @@ function themeLines(th: Theme, lang: Lang): string[] {
 }
 
 /** the closing guidance; the lines that depend on the target are written for the chosen platform */
-const GENERAL: Record<Lang, (string | ((pl: Platform) => string))[]> = {
+const GENERAL: Record<Lang, (string | ((pl: Platform) => string))[]> = withArabic({
   ja: [
     "まず画面の目的から「これは何のアプリか」を判断し、そのカテゴリのアプリとして一般に期待される機能（作成・一覧・詳細・編集・削除・検索・設定など、該当するもの）を、スケッチに描かれていなくても一通り実装する。",
     (pl: Platform) => `データは本物として扱う。ユーザーが作成したデータは${pl === "web" ? "ブラウザに（IndexedDB など）" : "端末に（Room や DataStore など）"}永続化し、${pl === "web" ? "再読み込み" : "再起動"}後も残す。ダミーやサンプルのデータは入れず、何もない状態には空の案内を表示する。入力は検証し、失敗や削除は適切に確認・通知する。`,
@@ -1147,10 +1155,10 @@ const GENERAL: Record<Lang, (string | ((pl: Platform) => string))[]> = {
     "아이콘은 Material Symbols Rounded를 사용한다.",
     (pl: Platform) => `${pl === "web" ? "브라우저" : "에뮬레이터나 실제 기기"} 동작 검증은 필요 없다. 구현 후 ${pl === "web" ? "production build를 실행하고 그 출력" : "서명된 release APK"}을 결과물로 제공한다.`,
   ],
-};
+});
 
 /** notes that differ on the web, where a browser has no status bar or gesture area to inset for */
-const STYLE_NOTES_WEB: Record<Lang, Partial<Record<Kind, string>>> = {
+const STYLE_NOTES_WEB: Record<Lang, Partial<Record<Kind, string>>> = withArabic({
   ko: {
     topAppBar: "상단 앱 바: 높이 64dp, 배경 surface. 제목은 titleLarge, 양쪽 아이콘 버튼은 48dp를 사용한다. 스크롤 시 surfaceContainer로 색상이 바뀌는 표준 동작을 사용한다.",
     bottomNav: "내비게이션 바: 높이 80dp, 배경 surfaceContainer. 선택 항목은 secondaryContainer 알약 표시기(64×32dp), 채운 아이콘과 labelMedium 레이블로 표시한다.",
@@ -1167,7 +1175,7 @@ const STYLE_NOTES_WEB: Record<Lang, Partial<Record<Kind, string>>> = {
     topAppBar: "顶部应用栏：高 64dp，背景为 surface。标题用 titleLarge，左右图标按钮 48dp。滚动时变为 surfaceContainer 的标准行为即可。",
     bottomNav: "导航栏：高 80dp，背景为 surfaceContainer。选中项用 secondaryContainer 的胶囊指示器（宽 64dp、高 32dp）表示，图标为填充样式，标签用 labelMedium。",
   },
-};
+});
 
 /* ---------- fixed phrases ---------- */
 
@@ -1183,7 +1191,7 @@ const sizeLabel = (f: Frame, vp: Viewport, lang: Lang): string | undefined => {
   if (vp !== "mixed") return undefined;
   const { w, h } = frameSizeOf(f);
   const kind = isPhoneFrame(f) ? { ja: "スマホ", en: "phone", zh: "手机", ko: "휴대전화" } : { ja: "デスクトップ", en: "desktop", zh: "桌面", ko: "데스크톱" };
-  return `${kind[lang]} ${w}×${h}`;
+  return `${kind[promptLang(lang)]} ${w}×${h}`;
 };
 
 const PH = {
@@ -1347,6 +1355,7 @@ const PH = {
 };
 
 export function buildPrompt(doc: Doc, widths: Record<string, number>, onlyFrameId?: string, lang: Lang = getLang()): string {
+  lang = promptLang(lang);
   doc = { ...doc, groups: constrainModalRails(doc.groups) };
   const th = normalizeTheme(doc.theme);
   const pal = paletteOf(doc.paletteKey, doc.customPalette, th);
@@ -1363,7 +1372,7 @@ export function buildPrompt(doc: Doc, widths: Record<string, number>, onlyFrameI
     .flatMap((g) => explodeGroup(g, widths));
   const lines: string[] = [];
   const q = quote(lang);
-  const ph = PH[lang];
+  const ph = PH[promptLang(lang)];
 
   const byFrame = new Map<string, Group[]>();
   const loose: Group[] = [];

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -356,6 +356,7 @@ export const LANG_FONT: Record<Lang, { family: string; google: string } | null> 
   ja: { family: "'Noto Sans JP'", google: "Noto+Sans+JP:wght@400;500;600;700" },
   zh: { family: "'Noto Sans SC'", google: "Noto+Sans+SC:wght@400;500;600;700" },
   ko: { family: "'Noto Sans KR'", google: "Noto+Sans+KR:wght@400;500;600;700" },
+  ar: { family: "'Noto Sans Arabic'", google: "Noto+Sans+Arabic:wght@400;500;600;700" },
   en: null,
 };
 


### PR DESCRIPTION
## What and why

Adds **Arabic** as a fifth UI language, written right to left.

- `lib/i18n.ts`: `ar` in `Lang`, `LANGS` and `isLang`; an `AR` table with every UI key, kept the way `KO` is kept; Arabic entries in `SEED_TEXT`, `COLOR_TOKEN_TEXT`, `KIND_TEXT` (all 35 kinds with their default labels and supporting text), `TAB_LABELS`, `SELECT_OPTIONS`, `FAB_MENU_TABS`, `NAV_TABS`, `TRANSITION_TEXT` and `SWIPE_TEXT`; and an `isRtl` helper.
- `app/page.tsx`: when the language is Arabic the root element gets `dir="rtl"`, so the panels, menus and text mirror; an Arabic browser locale is detected like the others; and a new `?lang=` query parameter names the language outright, for a link that must open in one language whatever the browser or the last visit says (this is how we embed the editor).
- `lib/tokens.ts`: `LANG_FONT.ar` → Noto Sans Arabic, loaded the way the CJK faces are. `lib/ai.ts`: `LANG_NAME.ar` so the in-editor AI answers in Arabic. `components/PartsPalette.tsx` category names and `components/Inspector.tsx` "N selected" spacing.
- **The generated prompt stays in English for Arabic**, on purpose: it is read by a coding agent, and the prompt templates keep their four voices. `promptLang` maps `ar` → `en` at the single entry point (`buildPrompt`) and the prompt tables are wrapped in `withArabic`, which lets Arabic read the English entry — no template is duplicated. An Arabic prompt voice can follow as its own PR if you would like one.
- CONTRIBUTING and the PR template now say five UI languages / four prompt languages.

Why here rather than in a wrapper: we embed M3E Canvas inside an Arabic desktop workspace and wanted the editor itself to read right to left, not a dictionary painted over it.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes — the parity tests now treat `KO` and `AR` alike as side tables keyed like the main dictionary, check that every key has an Arabic string and that the `{url}` / `{idea}` placeholders survive, and a new test asserts the Arabic editor writes an English prompt (616 tests)
- [x] `npm run build` passes
- [x] New or changed UI strings exist in Japanese, English, Chinese, Korean and Arabic; prompt text in the first four (unchanged)
- [x] Tried it in the editor: opened `?lang=ar` in Chromium — `lang=ar`, `dir=rtl`, the parts panel sits on the right with Arabic headings, the sample phone screen shows Arabic seed text, the language menu lists «العربية» and switching to it mirrors the layout; also embedded in our workspace where it is used daily. Not tried on a phone beyond the language menu.

## Screenshots

Live build of this branch: https://muhammedmj1.github.io/m3e-canvas/?lang=ar

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Arabic as a fifth UI language with right-to-left layout, so the editor mirrors its panels, menus, and text when Arabic is selected.

- Arabic covers every UI string, part defaults, tabs, menus, transitions, and color-role names across the editor.
- A `?lang=` query parameter forces the language for links that must open in one language.
- Arabic browser locales are detected, and Noto Sans Arabic is loaded like the other language faces.
- The generated AI prompt deliberately stays English for Arabic since a coding agent reads it; `promptLang` maps `ar` to `en` at the single entry point.
- Parity tests treat `KO` and `AR` alike as side tables and assert Arabic editors write English prompts.

<sup>Written for commit a7eb874a4b4bd4f4ee67ffddcafd36f494145436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

