### PR TITLE
Add mocked-fetch unit tests for lib/ai.ts

### DIFF
--- a/lib/ai.test.ts
+++ b/lib/ai.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { complete, hasKey, isSecureUrl, type AiSettings, type Provider } from "./ai";
+
+const settings = (over: Partial<AiSettings> = {}): AiSettings =>
+  ({ provider: "openai", baseUrl: "https://api.example.test", model: "test-model", key: "test-key", ...over });
+
+const jsonResponse = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status });
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("complete on the claude path", () => {
+  it("posts to the messages endpoint with the anthropic headers and body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ content: [{ type: "text", text: "hi" }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    const s = settings({ provider: "claude", baseUrl: "https://api.example.test/", key: "  test-key  " });
+    await expect(complete(s, "sys prompt", "user prompt")).resolves.toBe("hi");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example.test/v1/messages");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "content-type": "application/json",
+      "x-api-key": "test-key",
+      "anthropic-version": "2023-06-01",
+      "anthropic-dangerous-direct-browser-access": "true",
+    });
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({ model: "test-model", max_tokens: 4096, system: "sys prompt", messages: [{ role: "user", content: "user prompt" }] });
+  });
+
+  it("joins only the text blocks of the reply", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({
+      content: [{ type: "text", text: "a" }, { type: "tool_use", id: "t" }, { type: "text", text: "b" }],
+    })));
+    await expect(complete(settings({ provider: "claude" }), "s", "u")).resolves.toBe("ab");
+  });
+
+  it("returns an empty string for an empty content array instead of throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ content: [] })));
+    await expect(complete(settings({ provider: "claude" }), "s", "u")).resolves.toBe("");
+  });
+
+  it("throws long when the reply stops at max_tokens", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ content: [{ type: "text", text: "partial" }], stop_reason: "max_tokens" })));
+    await expect(complete(settings({ provider: "claude" }), "s", "u")).rejects.toThrow("long");
+  });
+
+  it("throws refusal when the model refuses", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: "refusal" })));
+    await expect(complete(settings({ provider: "claude" }), "s", "u")).rejects.toThrow("refusal");
+  });
+
+  it("throws the status and provider detail on an http error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: { message: "overloaded" } }), { status: 529, statusText: "Overloaded" })));
+    await expect(complete(settings({ provider: "claude" }), "s", "u")).rejects.toThrow("529 Overloaded: overloaded");
+  });
+});
+
+describe("complete on the openai-compatible path", () => {
+  it("sends bearer auth and omits max_tokens for the openai provider", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "stop", message: { content: "ok" } }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(complete(settings(), "sys prompt", "user prompt")).resolves.toBe("ok");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example.test/chat/completions");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ "content-type": "application/json", authorization: "Bearer test-key" });
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({ model: "test-model", messages: [{ role: "system", content: "sys prompt" }, { role: "user", content: "user prompt" }] });
+    expect(body).not.toHaveProperty("max_tokens");
+  });
+
+  it.each(["gemini", "deepseek"] as Provider[])("sends a max_tokens budget to %s", async (provider) => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "stop", message: { content: "ok" } }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(complete(settings({ provider }), "s", "u")).resolves.toBe("ok");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).max_tokens).toBe(4096);
+  });
+
+  it("calls a local endpoint without a key and without an authorization header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ choices: [{ message: { content: "local" } }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    const s = settings({ baseUrl: "http://localhost:11434/v1/", key: "" });
+    await expect(complete(s, "s", "u")).resolves.toBe("local");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:11434/v1/chat/completions");
+    expect(init.headers).toEqual({ "content-type": "application/json" });
+  });
+
+  it("joins array content parts", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ choices: [{ message: { content: [{ text: "a" }, {}, { text: "b" }] } }] })));
+    await expect(complete(settings(), "s", "u")).resolves.toBe("ab");
+  });
+
+  it("throws long when finish_reason is length", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "length", message: { content: "partial" } }] })));
+    await expect(complete(settings(), "s", "u")).rejects.toThrow("long");
+  });
+
+  it("throws empty when the reply has no content", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "stop", message: {} }] })));
+    await expect(complete(settings(), "s", "u")).rejects.toThrow("empty");
+  });
+});
+
+describe("complete input guards", () => {
+  it.each([
+    ["insecure", { baseUrl: "http://api.example.test" }],
+    ["model", { model: "  " }],
+  ])("rejects %s without calling fetch", async (message, over) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(complete(settings(over), "s", "u")).rejects.toThrow(message);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("hasKey and isSecureUrl", () => {
+  it("requires a key for hosted endpoints but not for this machine", () => {
+    expect(hasKey(settings())).toBe(true);
+    expect(hasKey(settings({ key: "  " }))).toBe(false);
+    expect(hasKey(settings({ key: "", baseUrl: "http://localhost:11434/v1" }))).toBe(true);
+  });
+
+  it("only allows https or an endpoint on this machine", () => {
+    expect(isSecureUrl("https://api.example.test/v1")).toBe(true);
+    expect(isSecureUrl("http://localhost:8080/v1")).toBe(true);
+    expect(isSecureUrl("http://127.0.0.1:8080/v1")).toBe(true);
+    expect(isSecureUrl("http://[::1]:8080/v1")).toBe(true);
+    expect(isSecureUrl("http://api.example.test/v1")).toBe(false);
+  });
+});

--- a/lib/ai.test.ts
+++ b/lib/ai.test.ts
@@ -96,6 +96,11 @@ describe("complete on the openai-compatible path", () => {
     await expect(complete(settings(), "s", "u")).rejects.toThrow("long");
   });
 
+  it("throws the status and provider detail on an http error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: { message: "bad key" } }), { status: 401, statusText: "Unauthorized" })));
+    await expect(complete(settings(), "s", "u")).rejects.toThrow("401 Unauthorized: bad key");
+  });
+
   it("throws empty when the reply has no content", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "stop", message: {} }] })));
     await expect(complete(settings(), "s", "u")).rejects.toThrow("empty");


### PR DESCRIPTION
Fixes #390

## What and why

Adds `lib/ai.test.ts`: 18 mocked-`fetch` unit tests pinning the current behavior of the AI request/response boundary (`complete`, `hasKey`, `isSecureUrl`), so regressions in this layer can no longer pass typecheck and build while breaking AI requests at runtime.

Follows the constraints from #390 and the maintainer's notes:

- One file, `lib/ai.test.ts`, next to the other `lib/*.test.ts` tests; `fetch` stubbed with `vi.stubGlobal` and restored in `afterEach` (the `lib/share.test.ts` pattern).
- Node environment: `loadAiSettings` / `saveAiSettings` are skipped (they need `localStorage`).
- No changes to `lib/ai.ts`; no request-body snapshots; no assertions that mirror implementation details.
- Pins the three behaviors named in the review notes:
  - Claude path with an empty `content` array returns `""` rather than throwing.
  - `stop_reason: "max_tokens"` (Claude) and `finish_reason: "length"` (OpenAI-compatible) both throw `Error("long")`.
  - Only `provider: "openai"` omits `max_tokens` from the body; Gemini and DeepSeek send it.
- Covers the issue scope: the Claude and OpenAI-compatible request paths, expected authentication headers, local endpoints without a key, rejection of insecure remote HTTP endpoints, normal text response parsing, and the refusal / empty / HTTP-error paths (401 on the OpenAI-compatible path, 529 on the Claude path).

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (657 tests, 18 of them new)
- [x] `npm run build` passes
- [x] No new UI strings or prompt text (test file only)
- [x] Regression-verified: on a pristine `main` we injected the following type-safe edits, each passing typecheck (and build, where checked) but caught precisely by the new tests — truncation checks removed (`max_tokens` / `finish_reason: "length"`), empty Claude `content` changed to throw, `max_tokens` omitted for all providers, and a Claude endpoint URL typo — while the untouched baseline stays 18/18 green with zero false positives.

## Screenshots

Not visual; `npx vitest run lib/ai.test.ts` → 18 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `lib/ai.test.ts` with 18 mocked-`fetch` unit tests pinning the behavior of `complete`, `hasKey`, and `isSecureUrl` so regressions in the AI request layer can't pass typecheck and build while breaking requests at runtime.

**Notes**
- Test-only change; no modifications to `lib/ai.ts`.
- Skips `loadAiSettings`/`saveAiSettings` since they require `localStorage`.

<sup>Written for commit cf6ad904c808ee6df18633f7f4e5f0340ca2d0b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

