### PR TITLE
docs: fix grammar issue in public/agent.md

### DIFF
--- a/public/agent.md
+++ b/public/agent.md
@@ -55,7 +55,7 @@ Rough placement is fine. The person presses **Tidy** and bars snap to the edges,
 
 ### Screens (`frames`)
 
-A phone screen is **412 × 892**; a desktop screen is **1280 × 800** (set `w` and `h`). Place screens side by side on the canvas, 80 apart:
+A phone screen is **412 × 892**; a desktop screen is **1280 × 800** (set `w` and `h`). Place screens side by side on the canvas, 80 dp apart:
 
 ```json
 { "id": "home", "name": "Home", "x": 0, "y": 0, "note": "Lists the saved recipes." }


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `public/agent.md` (line 58).

## Problem

The distance "80" is missing its unit. Elsewhere the doc is precise about units ("16dp margins", "412 × 892"), so "80 apart" reads as incomplete.

The problematic text:

```markdown
Place screens side by side on the canvas, 80 apart:
```

## Fix

Replaced with:

```markdown
Place screens side by side on the canvas, 80 dp apart:
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the screen-placement guidance in `public/agent.md` by specifying that screens should be placed 80 dp apart.

<sup>Written for commit 0850559addf66e9197348cd1f6fbae281497ab57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

