### PR TITLE
docs: fix grammar issue in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ and, if you turn it on, the optional AI helper: with your own API key entered in
 the AI tab, the browser sends the generated description of your whole design
 straight to the provider you chose (OpenAI, Anthropic, Google or DeepSeek) and
 nothing else. The key is kept in this browser's local storage under `m3e:ai` and
-never appears in the prompt, an exported image or the saved document. That keeps
+never appears in the prompt, in an exported image, or in the saved document. That keeps
 the attack surface small, but if you find something, please tell us.
 
 ## Reporting


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `SECURITY.md` (line 8).

## Problem

Broken parallelism: the preposition "in" is dropped before the second and third items of the list.

The problematic text:

```markdown
never appears in the prompt, an exported image or the saved document
```

## Fix

Replaced with:

```markdown
never appears in the prompt, in an exported image, or in the saved document
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a grammar issue in `SECURITY.md` by restoring parallel structure in the list describing where the API key does not appear.

<sup>Written for commit d4f7b5c9360d1a91addabe48881b19b779c45124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

