### PR TITLE
Register the editor's operations as WebMCP tools

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,12 +87,13 @@ import { PartsPalette } from "@/components/PartsPalette";
 import { PromptPanel } from "@/components/PromptPanel";
 import { GitHubLink, Mode, Toolbar } from "@/components/Toolbar";
 import { LangMenu } from "@/components/Menus";
-import { AiActionKey, AiPanel, aiErrorText } from "@/components/AiPanel";
+import { AiActionKey, AiPanel, McpState, aiErrorText } from "@/components/AiPanel";
 import { TidyState } from "@/components/ui";
 import { AiSettings, DEFAULT_AI, hasKey, isSecureUrl, loadAiSettings, proposeBehavior, proposeDescription, pushHistory, saveAiSettings } from "@/lib/ai";
 import { barSlotOf, bodyRect, carryFrame, pullInto, tidyFrame } from "@/lib/tidy";
 import { constrainModalRails, modalRailOf, updateRail } from "@/lib/rail";
 import { isProject, readProject, saveProject } from "@/lib/project";
+import { AddPartSpec, EditorToolApi, PartBox, agentSize, agentSlot, editorTools, getModelContext, loadWebMcpEnabled, registerTools, saveWebMcpEnabled } from "@/lib/webmcp";
 import { hasShareHash, readShareHash } from "@/lib/share";
 import { LoadingIndicator } from "@/components/Loading";
 import { draftDesign } from "@/lib/ai";
@@ -1727,17 +1728,20 @@ export default function Page() {
     };
   };
 
-  const patchSelected = (patch: Partial<Item>) => {
-    if (!primaryId) return;
-    const id = primaryId;
+  /** One part edited on the inspector's terms: a locked group refuses a resize, a rail
+   *  reflows the screen around it, and a lone part keeps whatever it was lined up with.
+   *  False when the edit was refused. */
+  const patchItem = (id: string, patch: Partial<Item>, collapse = true): boolean => {
     /* a rail state change resizes it too, so it counts as a resize for the lock */
     const resizes = "size" in patch || "size2" in patch || "railExpanded" in patch || "railModal" in patch;
     /* a resize would reflow and move the locked group; other edits leave its layout alone */
     if (resizes && groupsRef.current.some((g) => g.locked && g.items.some((it) => it.id === id))) {
       showToast(lockedGroupMsg());
-      return;
+      return false;
     }
-    snapshotFor(id + ":" + Object.keys(patch).join(","));
+    /* a drag or a held key is one undo step; a caller that arrives complete asks for its own */
+    if (collapse) snapshotFor(id + ":" + Object.keys(patch).join(","));
+    else snapshot();
     setGroups((prev) =>
       "railExpanded" in patch || "railModal" in patch ? updateRail(prev, framesRef.current, widthsRef.current, id, patch) : prev.map((g) => {
         const idx = g.items.findIndex((it) => it.id === id);
@@ -1756,18 +1760,17 @@ export default function Page() {
     if (dragRef.current?.item.id === id) {
       dragRef.current.item = { ...dragRef.current.item, ...patch };
     }
+    return true;
   };
 
-  const deleteSelected = useCallback(() => {
-    if (selectedIds.length === 0) return;
-    const ids = new Set(selectedIds);
-    /* nothing deletable when every selected part sits in a locked group: no snapshot, keep the selection */
-    if (groupsRef.current.every((g) => g.locked || !g.items.some((it) => ids.has(it.id)))) {
-      showToast(lockedGroupMsg());
-      return;
-    }
-    snapshot();
-    setGroups((prev) =>
+  const patchSelected = (patch: Partial<Item>) => {
+    if (primaryId) patchItem(primaryId, patch);
+  };
+
+  /** The groups with `ids` gone: a locked group keeps its parts, a run closes the gap
+   *  they leave at its head, and a group emptied out drops away. */
+  const withoutItems = useCallback(
+    (prev: Group[], ids: Set<string>) =>
       prev
         .map((g) => {
           /* Delete / Backspace leaves a locked group and its parts alone */
@@ -1786,9 +1789,21 @@ export default function Page() {
           return { ...g, x, y, items: items.filter((it) => !ids.has(it.id)) };
         })
         .filter((g) => g.items.length > 0),
-    );
+    [],
+  );
+
+  const deleteSelected = useCallback(() => {
+    if (selectedIds.length === 0) return;
+    const ids = new Set(selectedIds);
+    /* nothing deletable when every selected part sits in a locked group: no snapshot, keep the selection */
+    if (groupsRef.current.every((g) => g.locked || !g.items.some((it) => ids.has(it.id)))) {
+      showToast(lockedGroupMsg());
+      return;
+    }
+    snapshot();
+    setGroups((prev) => withoutItems(prev, ids));
     setSelectedIds([]);
-  }, [selectedIds, snapshot]);
+  }, [selectedIds, snapshot, setGroups, withoutItems]);
 
   const duplicateSelected = useCallback(() => {
     if (!selected) return;
@@ -2887,6 +2902,139 @@ export default function Page() {
   const docRef = useRef(doc);
   docRef.current = doc;
 
+  /* ---------- webmcp: the browser's agent works the canvas ---------- */
+
+  /** Places one part on a screen the way the palette's drop does, minus the drag: sized for
+   *  the screen, at the slot `agentSlot` picks, pulled inside the edges, and selected so the
+   *  author sees it land. The slot is worked out inside the updater, so two calls in one task
+   *  do not both aim at the same gap. */
+  const addPartForAgent = (spec: AddPartSpec): { item: Item; frame: Frame; at: PartBox } | null => {
+    const frames = framesRef.current;
+    const target = spec.screen ? frames.find((f) => f.id === spec.screen || f.name === spec.screen) : frames[0];
+    if (!target) return null;
+    const item = makeItem(spec.kind);
+    if (spec.label !== undefined) item.label = spec.label;
+    if (spec.supporting !== undefined) item.supporting = spec.supporting;
+    if (spec.icon !== undefined) item.icon = spec.icon;
+    if (spec.variant !== undefined) item.variant = spec.variant;
+    const widths = widthsRef.current;
+    const groups = groupsRef.current;
+    const sized = agentSize(item, target, groups, frames, widths);
+    const { x, y } = agentSlot(sized, target, groups, frames, widths);
+    const placed = pullInto({ id: uid(), x, y, axis: "x" as Axis, items: [sized] }, target, widths);
+    snapshot();
+    tidyRef.current = null;
+    setGroups((gs) => [...gs, placed]);
+    setSelectedIds([sized.id]);
+    setSelectedFrameId(null);
+    const box = sizeOf(sized, widths);
+    return { item: sized, frame: target, at: { x: placed.x, y: placed.y, w: box.w, h: box.h } };
+  };
+
+  /** Every operation a tool may reach. Each goes through the editor's own path, so an agent's
+   *  change is one undo away exactly like the author's. Reading the live document from a ref is
+   *  safe because the spec runs each tool execution as its own task, and React has flushed the
+   *  previous call's state by the time the next task starts. */
+  const mcpApi: EditorToolApi = {
+    doc: () => docRef.current,
+    widths: () => widthsRef.current,
+    lang: () => getLang(),
+    prompt: (frameId) => (frameId ? buildPrompt(docRef.current, widthsRef.current, frameId, getLang()) : effectivePrompt(docRef.current, widthsRef.current, getLang())),
+    addPart: addPartForAgent,
+    updatePart: (id, patch) => {
+      const before = groupsRef.current.flatMap((g) => g.items).find((it) => it.id === id);
+      if (!before) return null;
+      /* a refused edit leaves the author's selection where it was */
+      if (!patchItem(id, patch, false)) throw new Error("that part sits in a locked group; unlock it in the Layers panel first");
+      setSelectedIds([id]);
+      setSelectedFrameId(null);
+      return { ...before, ...patch };
+    },
+    deletePart: (id) => {
+      const g = groupsRef.current.find((x) => x.items.some((it) => it.id === id));
+      if (!g || g.locked) return false;
+      snapshot();
+      setGroups((prev) => withoutItems(prev, new Set([id])));
+      setSelectedIds((prev) => prev.filter((x) => x !== id));
+      return true;
+    },
+    addScreen: (name) => {
+      const frame: Frame = { id: uid(), name: name?.trim() || `${t("screenN")} ${framesRef.current.length + 1}`, x: nextFrameX(), y: framesRef.current[0]?.y ?? 0 };
+      snapshot();
+      setFrames((fs) => [...fs, frame]);
+      setSelectedFrameId(frame.id);
+      setSelectedIds([]);
+      return frame;
+    },
+    updateScreen: (id, patch) => {
+      const before = framesRef.current.find((f) => f.id === id);
+      if (!before) return null;
+      snapshot();
+      setFrames((fs) => fs.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+      /* a new place asks for a new layout, so the last tidy is no longer the one to undo */
+      if (patch.place !== undefined && patch.place !== before.place) tidyRef.current = null;
+      return { ...before, ...patch };
+    },
+    tidyScreen: (id) => {
+      const f = framesRef.current.find((x) => x.id === id);
+      if (!f) return false;
+      const after = tidyFrame(groupsRef.current, f, framesRef.current, widthsRef.current);
+      if (!after) return false;
+      snapshot();
+      tidyRef.current = { frameId: f.id, before: groupsRef.current, after };
+      setGroups(after);
+      return true;
+    },
+    /* one snapshot for the whole call, so a scheme and an axis set together undo together */
+    setTheme: (patch, palette) => {
+      snapshot(true);
+      if (palette) setPaletteKey(palette);
+      if (Object.keys(patch).length) setTheme((prev) => ({ ...prev, ...patch }));
+    },
+    setAppInfo: ({ title: next, brief: nextBrief }) => {
+      snapshot(true);
+      if (next !== undefined) setTitle(next);
+      if (nextBrief !== undefined) setBrief(nextBrief);
+    },
+    undo,
+  };
+  /** the same operations, for the tools registered on an earlier render */
+  const mcpApiRef = useRef(mcpApi);
+  mcpApiRef.current = mcpApi;
+
+  /* Nothing is offered until the stored answer has been read, so a browser told to keep
+   * its tools to itself never registers them, not even for a tick. Reading storage in a
+   * state initializer would disagree with the prerendered markup. */
+  const [mcp, setMcp] = useState<McpState>({ supported: false, enabled: false, tools: 0 });
+  useEffect(() => {
+    setMcp((s) => ({ ...s, supported: !!getModelContext(), enabled: loadWebMcpEnabled() }));
+  }, []);
+
+  /* The tools are registered once, and again when the language changes, because the browser
+   * shows each tool's title in its own UI. Aborting the controller unregisters them all. */
+  useEffect(() => {
+    const ctx = getModelContext();
+    /* a read-only tab saves nothing, so it offers nothing either */
+    if (!ctx || !mcp.enabled || isMobile || editAccess !== "editable") return;
+    const ac = new AbortController();
+    let live = true;
+    registerTools(editorTools(() => mcpApiRef.current), ctx, ac.signal).then((names) => {
+      if (live) setMcp((s) => ({ ...s, tools: names.length }));
+    });
+    return () => {
+      live = false;
+      ac.abort();
+      setMcp((s) => ({ ...s, tools: 0 }));
+    };
+    /* the operations are reached through mcpApiRef, so an edit must not rebuild the toolbox */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mcp.enabled, lang, isMobile, editAccess]);
+
+  const setMcpEnabled = (on: boolean) => {
+    saveWebMcpEnabled(on);
+    setMcp((s) => ({ ...s, enabled: on }));
+  };
+
   /** arrows from tappable parts to the frames they open */
   const links = useMemo(() => {
     if (frame !== "phone") return [];
@@ -3476,7 +3624,7 @@ export default function Page() {
                 ) : leftTab === "motion" ? (
                   <MotionPanel p={p} theme={theme} onChange={patchTheme} />
                 ) : leftTab === "ai" ? (
-                  <AiPanel p={p} settings={aiSettings} onSettings={updateAiSettings} />
+                  <AiPanel p={p} settings={aiSettings} onSettings={updateAiSettings} mcp={mcp} onMcpEnabled={setMcpEnabled} />
                 ) : (
                   <LayersPanel
                     p={p}

--- a/components/AiPanel.tsx
+++ b/components/AiPanel.tsx
@@ -5,6 +5,7 @@ import { Palette } from "@/lib/tokens";
 import { t, useLang } from "@/lib/i18n";
 import { AiSettings, PROVIDERS, Provider, providerSpec } from "@/lib/ai";
 import { Icon } from "./M3Node";
+import { Toggle } from "./ui";
 
 /** the message shown for a failed request, mapped from the error codes lib/ai throws */
 export function aiErrorText(e: unknown, lang: ReturnType<typeof useLang>): string {
@@ -160,8 +161,35 @@ function ProviderGroup({ value, onChange, p }: { value: Provider; onChange: (k: 
   );
 }
 
-/** The AI tab of the left rail: the provider settings. The actions live with each screen on the right. */
-export function AiPanel({ p, settings, onSettings }: { p: Palette; settings: AiSettings; onSettings: (s: AiSettings) => void }) {
+/** What WebMCP is doing on this page: how many of the editor's operations the browser's
+ *  agent can see, and the switch that stops offering them. */
+export type McpState = { supported: boolean; enabled: boolean; tools: number };
+
+function McpSection({ p, mcp, onEnabled }: { p: Palette; mcp: McpState; onEnabled: (on: boolean) => void }) {
+  const lang = useLang();
+  /* a page that registered nothing must not read as a page that is working */
+  const offering = mcp.supported && mcp.enabled && mcp.tools > 0;
+  const status = mcp.supported ? (mcp.enabled ? t("mcpReady", lang).replace("{n}", String(mcp.tools)) : null) : t("mcpUnsupported", lang);
+  return (
+    <div style={{ marginTop: 20, paddingTop: 16, borderTop: `1px solid ${p.outlineVariant}` }}>
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: 0.4, color: p.onSurfaceVariant, padding: "0 6px 12px" }}>{t("mcp", lang)}</div>
+      <div style={{ padding: "0 4px", display: "flex", flexDirection: "column", gap: 10 }}>
+        {/* a browser without the API has nothing to switch; the note below says so */}
+        {mcp.supported && <Toggle grow on={mcp.enabled} onChange={onEnabled} p={p} icon="handyman" label={t("mcpEnable", lang)} />}
+        <div style={{ fontSize: 12, lineHeight: 1.5, color: p.onSurfaceVariant, padding: "0 4px" }}>{t("mcpHint", lang)}</div>
+        {status && (
+          <div style={{ fontSize: 12, lineHeight: 1.5, color: offering ? p.primary : p.onSurfaceVariant, padding: "0 4px", fontWeight: offering ? 600 : 400 }} role="status">
+            {status}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** The AI tab of the left rail: the provider settings, then the tools this page offers
+ *  the browser's own agent. The per-screen actions live with each screen on the right. */
+export function AiPanel({ p, settings, onSettings, mcp, onMcpEnabled }: { p: Palette; settings: AiSettings; onSettings: (s: AiSettings) => void; mcp: McpState; onMcpEnabled: (on: boolean) => void }) {
   const lang = useLang();
   const spec = providerSpec(settings.provider);
   const pick = (k: Provider) => {
@@ -202,6 +230,7 @@ export function AiPanel({ p, settings, onSettings }: { p: Palette; settings: AiS
             <div style={{ fontSize: 12, lineHeight: 1.5, color: p.onSurfaceVariant, marginTop: 8, padding: "0 4px" }}>{t("aiKeyHint", lang)}</div>
           </div>
         </div>
+        <McpSection p={p} mcp={mcp} onEnabled={onMcpEnabled} />
       </div>
     </div>
   );

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -426,6 +426,32 @@ export const UI = {
     en: "Could not connect. Check the URL, the network and the server's CORS settings",
     zh: "无法连接。请检查 URL、网络和服务器的 CORS 设置",
   },
+  // webmcp: the browser's own agent works the canvas through the editor's operations
+  mcp: { ja: "ブラウザのエージェント", en: "Browser agent", zh: "浏览器智能体" },
+  mcpEnable: { ja: "この画面の操作を渡す", en: "Offer the editor's tools", zh: "开放编辑器操作" },
+  mcpHint: {
+    ja: "WebMCP に対応したブラウザのエージェントが、部品の追加や整列、テーマの変更をこのエディタと同じ手順で行えます。変更は取り消し履歴に残ります。",
+    en: "A WebMCP-capable browser agent can add parts, tidy screens and change the theme through the same operations the editor uses. Every change lands on the undo stack.",
+    zh: "支持 WebMCP 的浏览器智能体可以通过编辑器自身的操作添加组件、整理屏幕并修改主题。所有更改都会进入撤销记录。",
+  },
+  mcpReady: { ja: "{n} 個の操作を渡しています", en: "{n} tools offered", zh: "已开放 {n} 项操作" },
+  mcpUnsupported: {
+    ja: "このブラウザは WebMCP に未対応です。対応ブラウザで開くと自動で有効になります。",
+    en: "This browser does not offer WebMCP yet. The tools appear on their own in one that does.",
+    zh: "此浏览器尚不支持 WebMCP。在支持的浏览器中打开即会自动启用。",
+  },
+  mcpToolListKinds: { ja: "部品の一覧", en: "List the parts", zh: "列出组件" },
+  mcpToolGetDocument: { ja: "下書きを読む", en: "Read the sketch", zh: "读取草图" },
+  mcpToolGetPrompt: { ja: "プロンプトを取得", en: "Get the prompt", zh: "获取提示词" },
+  mcpToolAddPart: { ja: "部品を置く", en: "Add a part", zh: "添加组件" },
+  mcpToolUpdatePart: { ja: "部品を変更", en: "Change a part", zh: "修改组件" },
+  mcpToolDeletePart: { ja: "部品を削除", en: "Delete a part", zh: "删除组件" },
+  mcpToolAddScreen: { ja: "画面を追加", en: "Add a screen", zh: "添加屏幕" },
+  mcpToolUpdateScreen: { ja: "画面を変更", en: "Change a screen", zh: "修改屏幕" },
+  mcpToolTidyScreen: { ja: "画面を整える", en: "Tidy a screen", zh: "整理屏幕" },
+  mcpToolSetTheme: { ja: "テーマを設定", en: "Set the theme", zh: "设置主题" },
+  mcpToolSetAppInfo: { ja: "アプリの説明を設定", en: "Set the app details", zh: "设置应用信息" },
+  mcpToolUndo: { ja: "元に戻す", en: "Undo one step", zh: "撤销一步" },
 } as const satisfies Record<string, Str>;
 
 export type UIKey = keyof typeof UI;
@@ -493,6 +519,13 @@ export const KO: Record<UIKey, string> = {
   aiSelectScreen: "먼저 화면을 선택하세요", aiNoKey: "AI 탭에 키를 입력하면 사용할 수 있습니다", aiError: "AI 요청에 실패했습니다",
   aiErrorRefusal: "모델이 답변을 거부했습니다", aiErrorJson: "모델의 응답을 읽을 수 없습니다", aiErrorLong: "답변이 너무 길어 중간에 잘렸습니다. 화면 수를 줄여 다시 시도하세요", aiErrorModel: "모델 ID를 입력하세요",
   aiErrorInsecure: "기본 URL은 https를 사용하거나 localhost를 가리켜야 합니다", aiErrorNetwork: "연결할 수 없습니다. URL, 네트워크 및 서버의 CORS 설정을 확인하세요",
+  mcp: "브라우저 에이전트", mcpEnable: "에디터 동작 제공", mcpReady: "{n}개의 동작을 제공하고 있습니다",
+  mcpHint: "WebMCP를 지원하는 브라우저 에이전트가 에디터와 같은 동작으로 부품을 추가하고 화면을 정리하며 테마를 바꿀 수 있습니다. 모든 변경은 실행 취소 기록에 남습니다.",
+  mcpUnsupported: "이 브라우저는 아직 WebMCP를 지원하지 않습니다. 지원하는 브라우저에서 열면 자동으로 사용됩니다.",
+  mcpToolListKinds: "부품 목록", mcpToolGetDocument: "스케치 읽기", mcpToolGetPrompt: "프롬프트 가져오기",
+  mcpToolAddPart: "부품 추가", mcpToolUpdatePart: "부품 변경", mcpToolDeletePart: "부품 삭제",
+  mcpToolAddScreen: "화면 추가", mcpToolUpdateScreen: "화면 변경", mcpToolTidyScreen: "화면 정리",
+  mcpToolSetTheme: "테마 설정", mcpToolSetAppInfo: "앱 정보 설정", mcpToolUndo: "한 단계 실행 취소",
 };
 
 export const t = (key: UIKey, lang: Lang = current): string => (lang === "ko" ? KO[key] : UI[key][lang]);

--- a/lib/tidy.ts
+++ b/lib/tidy.ts
@@ -155,16 +155,25 @@ function rowsOf(units: Unit[]): Unit[][] {
   return out;
 }
 
-const isRail = (u: Unit) => u.kind === "navRail";
-const isTop = (u: Unit) => u.kind === "topAppBar" || u.kind === "tabs";
-const isBottomBar = (u: Unit) => u.kind === "bottomNav" || (u.kind === "box" && !!u.checked);
-const isFloatingBottom = (u: Unit) => u.kind === "toolbar" || u.kind === "snackbar";
-const isFab = (u: Unit) => u.kind === "fab" || u.kind === "extendedFab" || u.kind === "fabMenu";
-const isOverlay = (u: Unit) => u.kind === "dialog";
+/** the only fields the classifiers below read; a Unit and a bare part both satisfy it */
+type Placement = { kind: string; checked?: boolean };
+
+const isRail = (u: Placement) => u.kind === "navRail";
+const isTop = (u: Placement) => u.kind === "topAppBar" || u.kind === "tabs";
+const isBottomBar = (u: Placement) => u.kind === "bottomNav" || (u.kind === "box" && !!u.checked);
+const isFloatingBottom = (u: Placement) => u.kind === "toolbar" || u.kind === "snackbar";
+const isFab = (u: Placement) => u.kind === "fab" || u.kind === "extendedFab" || u.kind === "fabMenu";
+const isOverlay = (u: Placement) => u.kind === "dialog";
 /** a line of text, and the small controls that pair with one across a row */
-const isLabel = (u: Unit) => u.kind === "text";
-const isControl = (u: Unit) => u.kind === "switch" || u.kind === "checkbox" || u.kind === "radio" || u.kind === "iconButton";
-const isAnchored = (u: Unit) => isRail(u) || isTop(u) || isBottomBar(u) || isFloatingBottom(u) || isFab(u) || isOverlay(u);
+const isLabel = (u: Placement) => u.kind === "text";
+const isControl = (u: Placement) => u.kind === "switch" || u.kind === "checkbox" || u.kind === "radio" || u.kind === "iconButton";
+const isAnchored = (u: Placement) => isRail(u) || isTop(u) || isBottomBar(u) || isFloatingBottom(u) || isFab(u) || isOverlay(u);
+
+/** Whether Tidy stacks this run in the body, rather than pinning it to an edge, floating it
+ *  above the bottom bar or centring it. A run takes its place from its first part, as the
+ *  clusters do. Placing a part outside Tidy reads the same split, so the two cannot
+ *  disagree about what shapes the body and what fills it. */
+export const isBodyRun = (g: Group) => !isAnchored({ kind: g.items[0].kind, checked: g.items[0].checked });
 
 /** where a unit sits horizontally, so tidying keeps a right-aligned part on the right.
  *  Judged from the edges, so a part already on the margin reads the same way after tidying. */

--- a/lib/webmcp.test.ts
+++ b/lib/webmcp.test.ts
@@ -1,0 +1,590 @@
+﻿import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AddPartSpec,
+  EditorToolApi,
+  ModelContext,
+  WebMcpTool,
+  agentSize,
+  agentSlot,
+  describeDoc,
+  editorTools,
+  getModelContext,
+  isToolName,
+  loadWebMcpEnabled,
+  registerTools,
+  saveWebMcpEnabled,
+} from "./webmcp";
+import { Doc, Frame, Group, Item, KIND_ORDER, KIND_SPEC, NAV_BAR_H, PHONE_H, PHONE_MARGIN, PHONE_W, RAIL_COLLAPSED_W, STATUS_BAR_H, Theme, makeItem, sizeOf } from "./tokens";
+
+const home: Frame = { id: "f1", name: "Home", x: 0, y: 0 };
+const settings: Frame = { id: "f2", name: "Settings", x: 600, y: 0 };
+
+const part = (over: Partial<Item> = {}): Item => ({ id: "i1", kind: "button", label: "Save", icon: "add", variant: "filled", ...over });
+const run = (id: string, x: number, y: number, items: Item[]): Group => ({ id, x, y, axis: "x", items });
+
+const docOf = (over: Partial<Doc> = {}): Doc => ({ groups: [run("g1", PHONE_MARGIN, 120, [part()])], frames: [home, settings], paletteKey: "purple", frame: "phone", title: "Notes", brief: "Keep notes.", ...over });
+
+/** an editor holding exactly this one part, so the writing tools can find it by id */
+const editorWith = (item: Item) => fakeEditor(docOf({ groups: [run("g1", PHONE_MARGIN, 120, [item])] }));
+
+/** The editor stubbed out: the tools may only reach the canvas through these.
+ *  `settles` is false to model React, whose state has not changed yet when a tool returns. */
+function fakeEditor(doc: Doc = docOf(), settles = true) {
+  let current = doc;
+  const applied = (next: Doc) => {
+    if (settles) current = next;
+  };
+  const api = {
+    doc: vi.fn(() => current),
+    widths: vi.fn(() => ({}) as Record<string, number>),
+    lang: vi.fn(() => "en" as const),
+    prompt: vi.fn((frameId?: string) => `prompt:${frameId ?? "all"}`),
+    addPart: vi.fn((spec: AddPartSpec) => {
+      const item = { ...makeItem(spec.kind), id: "added", label: spec.label ?? "x", icon: spec.icon ?? null };
+      return { item, frame: home, at: { x: 16, y: 120, ...sizeOf(item, {}) } };
+    }),
+    updatePart: vi.fn((id: string, patch: Partial<Item>) => {
+      const found = current.groups.flatMap((g) => g.items).find((it) => it.id === id);
+      return found ? { ...found, ...patch } : null;
+    }),
+    deletePart: vi.fn((id: string) => current.groups.some((g) => g.items.some((it) => it.id === id))),
+    addScreen: vi.fn((name?: string) => ({ id: "f3", name: name ?? "Screen 3", x: 1200, y: 0 }) as Frame),
+    updateScreen: vi.fn((id: string, patch: Partial<Frame>) => ({ ...home, id, ...patch })),
+    tidyScreen: vi.fn(() => true),
+    setTheme: vi.fn((patch: Partial<Theme>, palette?: string) => {
+      applied({ ...current, paletteKey: palette ?? current.paletteKey, theme: { ...(current.theme ?? {}), ...patch } as Theme });
+    }),
+    setAppInfo: vi.fn((patch: { title?: string; brief?: string }) => applied({ ...current, ...patch })),
+    undo: vi.fn(),
+  } satisfies EditorToolApi;
+  return api;
+}
+
+const toolbox = (api: EditorToolApi) => new Map(editorTools(() => api).map((tool) => [tool.name, tool]));
+/** A tool as an agent reaches it: always a promise, so a refusal arrives as a rejection. */
+const call = async (tools: Map<string, WebMcpTool>, name: string, input: Record<string, unknown> = {}) => {
+  const tool = tools.get(name);
+  if (!tool) throw new Error(`no tool named ${name}`);
+  return await tool.execute(input);
+};
+
+describe("feature detection", () => {
+  it("finds nothing in a browser that does not implement the API", () => {
+    expect(getModelContext({} as Document)).toBeNull();
+    expect(getModelContext({ modelContext: {} } as unknown as Document)).toBeNull();
+  });
+
+  it("returns the page's model context once it offers registerTool", () => {
+    const ctx = { registerTool: async () => {} };
+    expect(getModelContext({ modelContext: ctx } as unknown as Document)).toBe(ctx);
+  });
+
+  it.each(["m3e_add_part", "m3e.add-part", "a", "x".repeat(128)])("accepts %s as a tool name", (name) => {
+    expect(isToolName(name)).toBe(true);
+  });
+
+  it.each(["", "x".repeat(129), "m3e add part", "m3e/add", "m3e:add", "パーツ"])("rejects %s as a tool name", (name) => {
+    expect(isToolName(name)).toBe(false);
+  });
+});
+
+describe("registerTools", () => {
+  const tool = (name: string): WebMcpTool => ({ name, title: name, description: name, execute: () => null });
+
+  it("registers every tool and passes the signal that unregisters them", async () => {
+    const seen: { tool: WebMcpTool; signal?: AbortSignal }[] = [];
+    const ctx: ModelContext = { registerTool: async (t, o) => void seen.push({ tool: t, signal: o?.signal }) };
+    const ac = new AbortController();
+    const names = await registerTools([tool("a"), tool("b")], ctx, ac.signal);
+    expect(names).toEqual(["a", "b"]);
+    expect(seen.map((s) => s.signal)).toEqual([ac.signal, ac.signal]);
+  });
+
+  it("keeps the rest of the toolbox when the browser turns one name down", async () => {
+    const ctx: ModelContext = { registerTool: async (t) => { if (t.name === "b") throw new Error("InvalidStateError"); } };
+    await expect(registerTools([tool("a"), tool("b"), tool("c")], ctx)).resolves.toEqual(["a", "c"]);
+  });
+
+  it("stops as soon as the signal is aborted", async () => {
+    const ctx: ModelContext = { registerTool: async () => {} };
+    const ac = new AbortController();
+    ac.abort();
+    await expect(registerTools([tool("a")], ctx, ac.signal)).resolves.toEqual([]);
+  });
+
+  it("hands the agent a rejection when a tool refuses on the spot", async () => {
+    let registered: WebMcpTool | null = null;
+    const ctx: ModelContext = { registerTool: async (t) => void (registered = t) };
+    const refuses: WebMcpTool = {
+      name: "m3e_x",
+      title: "x",
+      description: "x",
+      execute: () => {
+        throw new Error("id is required");
+      },
+    };
+    await registerTools([refuses], ctx);
+    /* the definition the browser holds answers with a promise, never a bare throw */
+    await expect((registered as unknown as WebMcpTool).execute({})).rejects.toThrow(/id is required/);
+  });
+});
+
+describe("the switch stored in this browser", () => {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+
+  beforeEach(() => store.clear());
+  afterEach(() => Reflect.deleteProperty(globalThis, "localStorage"));
+
+  const withStore = () => Object.defineProperty(globalThis, "localStorage", { value: stub, configurable: true });
+
+  it("offers the tools until this browser is told not to, and stores only the refusal", () => {
+    withStore();
+    expect(loadWebMcpEnabled()).toBe(true);
+    saveWebMcpEnabled(false);
+    expect(store.get("m3e:webmcp")).toBe("off");
+    expect(loadWebMcpEnabled()).toBe(false);
+    saveWebMcpEnabled(true);
+    expect(loadWebMcpEnabled()).toBe(true);
+    expect(store.has("m3e:webmcp")).toBe(false);
+  });
+
+  it("offers them where there is no storage to read, as on the server's first render", () => {
+    expect(loadWebMcpEnabled()).toBe(true);
+    expect(() => saveWebMcpEnabled(false)).not.toThrow();
+  });
+});
+
+describe("agentSlot", () => {
+  const at = (item: Item, groups: Group[] = []) => agentSlot(item, home, groups, [home, settings], {});
+
+  it("sends a top app bar to the top edge and a navigation bar to the bottom", () => {
+    expect(at(makeItem("topAppBar"))).toEqual({ x: 0, y: 0 });
+    expect(at(makeItem("bottomNav"))).toEqual({ x: 0, y: PHONE_H - (80 + NAV_BAR_H) });
+    expect(at(makeItem("navRail"))).toEqual({ x: 0, y: 0 });
+  });
+
+  it("puts the first body part on the layout margin", () => {
+    expect(at(part())).toEqual({ x: PHONE_MARGIN, y: PHONE_MARGIN });
+  });
+
+  it("stacks the next body part under the one already there, a margin below", () => {
+    const first = part({ id: "a" });
+    const groups = [run("g1", PHONE_MARGIN, PHONE_MARGIN, [first])];
+    const h = sizeOf(first, {}).h;
+    expect(at(part({ id: "b" }), groups)).toEqual({ x: PHONE_MARGIN, y: PHONE_MARGIN + h + PHONE_MARGIN });
+  });
+
+  it("starts the body below a top app bar rather than under it", () => {
+    const bar = makeItem("topAppBar");
+    const groups = [run("g1", 0, 0, [bar])];
+    expect(at(part(), groups)).toEqual({ x: PHONE_MARGIN, y: 64 + STATUS_BAR_H + PHONE_MARGIN });
+  });
+
+  it("treats a rail as shaping the body, not as something to stack under", () => {
+    /* a rail spans the whole body, so a geometric test mistakes it for body content and
+     * pushes the first part to the bottom edge; Tidy's own split does not */
+    const rail = makeItem("navRail");
+    const groups = [run("g1", 0, 0, [rail])];
+    expect(at(part(), groups)).toEqual({ x: RAIL_COLLAPSED_W + PHONE_MARGIN, y: PHONE_MARGIN });
+  });
+
+  it("stacks beside a rail rather than under the FAB or the snackbar above the bottom bar", () => {
+    for (const kind of ["fab", "snackbar", "dialog"] as const) {
+      const pinned = makeItem(kind);
+      const groups = [run("g1", 100, 600, [pinned])];
+      expect(at(part(), groups), kind).toEqual({ x: PHONE_MARGIN, y: PHONE_MARGIN });
+    }
+  });
+
+  it("keeps a part's middle on the screen when the body has no room left", () => {
+    const box = makeItem("box");
+    const groups = [run("g1", PHONE_MARGIN, PHONE_MARGIN, [{ ...box, id: "tall", size2: PHONE_H }])];
+    const slot = at(part(), groups);
+    const h = sizeOf(part(), {}).h;
+    expect(slot.y).toBeGreaterThan(PHONE_MARGIN);
+    /* still inside the frame, so the part belongs to this screen and Tidy can pick it up */
+    expect(slot.y + h / 2).toBeLessThanOrEqual(PHONE_H);
+  });
+});
+
+describe("agentSize", () => {
+  const sized = (item: Item, groups: Group[] = []) => agentSize(item, home, groups, [home, settings], {});
+
+  it("spans a bar across the screen", () => {
+    expect(sizeOf(sized(makeItem("topAppBar")), {}).w).toBe(PHONE_W);
+  });
+
+  it("spans a bar only across the room a rail leaves it", () => {
+    const groups = [run("g1", 0, 0, [makeItem("navRail")])];
+    expect(sizeOf(sized(makeItem("topAppBar"), groups), {}).w).toBe(PHONE_W - RAIL_COLLAPSED_W);
+  });
+
+  it("keeps a part no taller than the screen it goes on", () => {
+    const short: Frame = { ...home, h: 400 };
+    const tall = { ...makeItem("box"), size2: PHONE_H };
+    expect(sizeOf(agentSize(tall, short, [], [short], {}), {}).h).toBeLessThanOrEqual(400);
+  });
+});
+
+describe("describeDoc", () => {
+  it("reports the app, the theme and each screen with the parts on it", () => {
+    const groups = [run("g1", PHONE_MARGIN, 120, [part({ id: "save" })]), run("g2", 700, 120, [part({ id: "other" })])];
+    const shape = describeDoc(docOf({ groups }), {});
+    expect(shape.app).toMatchObject({ title: "Notes", brief: "Keep notes.", platform: "android", canvas: "phone" });
+    expect(shape.theme).toMatchObject({ palette: "purple", dark: false, shape: "rounded", motion: "standard" });
+    expect(shape.screens.map((s) => s.name)).toEqual(["Home", "Settings"]);
+    expect(shape.screens[0]).toMatchObject({ id: "f1", w: PHONE_W, h: PHONE_H, place: "top" });
+    /* each part is reported on the screen it stands on, with the id the tools take */
+    expect(shape.screens[0].parts.map((p) => p.id)).toEqual(["save"]);
+    expect(shape.screens[1].parts.map((p) => p.id)).toEqual(["other"]);
+    expect(shape.screens[0].parts[0]).toMatchObject({ kind: "button", label: "Save", icon: "add", variant: "filled", x: PHONE_MARGIN, y: 120 });
+  });
+
+  it("leaves out the fields a kind does not carry", () => {
+    const shape = describeDoc(docOf({ groups: [run("g1", 0, 0, [{ ...part({ id: "t", kind: "text", label: "Inbox" }) }])] }), {});
+    const text = shape.screens[0].parts[0];
+    expect(text.label).toBe("Inbox");
+    /* a text has no emphasis levels, so no variant is reported */
+    expect(text.variant).toBeUndefined();
+    expect(text.checked).toBeUndefined();
+  });
+});
+
+describe("the toolbox", () => {
+  it("gives every tool a spec-legal, unique name and a title and description", () => {
+    const tools = editorTools(() => fakeEditor());
+    expect(tools.length).toBeGreaterThan(0);
+    expect(new Set(tools.map((t) => t.name)).size).toBe(tools.length);
+    for (const tool of tools) {
+      expect(isToolName(tool.name), tool.name).toBe(true);
+      expect(tool.name.startsWith("m3e_"), tool.name).toBe(true);
+      expect(tool.title.trim(), tool.name).not.toBe("");
+      expect(tool.description.trim().length, tool.name).toBeGreaterThan(20);
+    }
+  });
+
+  it("marks the reading tools read-only and the writing tools consequential", () => {
+    for (const tool of editorTools(() => fakeEditor())) {
+      const reads = tool.name.startsWith("m3e_get") || tool.name.startsWith("m3e_list");
+      expect(tool.annotations?.readOnlyHint ?? false, tool.name).toBe(reads);
+      expect(tool.annotations?.consequentialHint ?? false, tool.name).toBe(!reads);
+    }
+  });
+
+  it("flags the tools that hand back the author's own words", () => {
+    const tools = toolbox(fakeEditor());
+    for (const name of ["m3e_get_document", "m3e_get_prompt"]) expect(tools.get(name)?.annotations?.untrustedContentHint, name).toBe(true);
+  });
+
+  it("only offers input fields it documents", () => {
+    for (const tool of editorTools(() => fakeEditor())) {
+      if (!tool.inputSchema) continue;
+      expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.additionalProperties).toBe(false);
+      for (const [key, spec] of Object.entries(tool.inputSchema.properties)) {
+        const described = spec as { type?: string; description?: string };
+        expect(described.type, `${tool.name}.${key}`).toBeTruthy();
+        expect(described.description?.trim(), `${tool.name}.${key}`).not.toBe("");
+      }
+      for (const key of tool.inputSchema.required ?? []) expect(Object.keys(tool.inputSchema.properties), tool.name).toContain(key);
+    }
+  });
+});
+
+describe("reading tools", () => {
+  it("lists every kind the editor can draw, with the variants it accepts", async () => {
+    const tools = toolbox(fakeEditor());
+    const listed = (await call(tools, "m3e_list_part_kinds")) as { kinds: { kind: string; accepts: string[]; variants?: string[] }[] };
+    expect(listed.kinds.map((k) => k.kind)).toEqual([...KIND_ORDER]);
+    const button = listed.kinds.find((k) => k.kind === "button");
+    expect(button?.accepts).toContain("label");
+    expect(button?.variants).toContain("tonal");
+    /* a text carries no emphasis levels, so none are offered */
+    expect(listed.kinds.find((k) => k.kind === "text")?.variants).toBeUndefined();
+  });
+
+  it("never writes to the canvas", async () => {
+    const api = fakeEditor(docOf({ groups: [run("g1", 0, 0, [part()])] }));
+    const tools = toolbox(api);
+    await call(tools, "m3e_list_part_kinds");
+    await call(tools, "m3e_get_document");
+    await call(tools, "m3e_get_prompt");
+    for (const write of [api.addPart, api.updatePart, api.deletePart, api.addScreen, api.updateScreen, api.tidyScreen, api.setTheme, api.setAppInfo, api.undo]) {
+      expect(write).not.toHaveBeenCalled();
+    }
+  });
+
+  it("takes a screen by name for the prompt, and the whole design without one", async () => {
+    const api = fakeEditor();
+    const tools = toolbox(api);
+    await expect(call(tools, "m3e_get_prompt")).resolves.toEqual({ prompt: "prompt:all" });
+    await expect(call(tools, "m3e_get_prompt", { screen: "Settings" })).resolves.toEqual({ prompt: "prompt:f2" });
+    expect(api.prompt).toHaveBeenLastCalledWith("f2");
+  });
+
+  it("says which screen it could not find", async () => {
+    const tools = toolbox(fakeEditor());
+    await expect(call(tools, "m3e_get_prompt", { screen: "Nope" })).rejects.toThrow(/no screen/);
+  });
+
+  it("asks for a screen before anything can be placed on one", async () => {
+    const tools = toolbox(fakeEditor(docOf({ frames: [] })));
+    await expect(call(tools, "m3e_tidy_screen")).rejects.toThrow(/m3e_add_screen/);
+  });
+});
+
+describe("m3e_add_part", () => {
+  it("places the kind it is given on the screen it names", async () => {
+    const api = fakeEditor();
+    await call(toolbox(api), "m3e_add_part", { kind: "card", screen: "Settings", label: "Notifications", supporting: "Push and email", variant: "tonal" });
+    expect(api.addPart).toHaveBeenCalledWith({ kind: "card", screen: "Settings", label: "Notifications", supporting: "Push and email", icon: undefined, variant: "tonal" });
+  });
+
+  it("refuses a field the kind does not carry, as the update tool does", async () => {
+    const tools = toolbox(fakeEditor());
+    /* a list item is always tonal on its fill; emphasis levels are not one of its fields */
+    await expect(call(tools, "m3e_add_part", { kind: "listItem", variant: "tonal" })).rejects.toThrow(/carries no variant/);
+    await expect(call(tools, "m3e_add_part", { kind: "button", supporting: "second line" })).rejects.toThrow(/carries no supporting/);
+  });
+
+  it("reports where the part landed, so the agent need not guess", async () => {
+    const result = (await call(toolbox(fakeEditor()), "m3e_add_part", { kind: "button" })) as { added: Record<string, unknown> };
+    expect(result.added).toMatchObject({ x: 16, y: 120 });
+    expect(result.added.h).toBeGreaterThan(0);
+  });
+
+  it("names the kinds it accepts when given one it does not know", async () => {
+    const tools = toolbox(fakeEditor());
+    await expect(call(tools, "m3e_add_part", { kind: "carousel" })).rejects.toThrow(/kind must be one of/);
+    await expect(call(tools, "m3e_add_part", {})).rejects.toThrow(/kind must be one of/);
+  });
+
+  it("reads an empty icon as no icon, and no icon field as the kind's default", async () => {
+    const api = fakeEditor();
+    const tools = toolbox(api);
+    await call(tools, "m3e_add_part", { kind: "button", icon: "" });
+    expect(api.addPart.mock.calls[0][0].icon).toBeNull();
+    await call(tools, "m3e_add_part", { kind: "button" });
+    expect(api.addPart.mock.calls[1][0].icon).toBeUndefined();
+  });
+
+  it("reports the screen the part landed on", async () => {
+    const tools = toolbox(fakeEditor());
+    const result = (await call(tools, "m3e_add_part", { kind: "fab" })) as { added: { id: string }; screen: { id: string; name: string } };
+    expect(result.screen).toEqual({ id: "f1", name: "Home" });
+    expect(result.added.id).toBe("added");
+  });
+
+  it("fails loudly when the editor could not place the part", async () => {
+    const api = fakeEditor();
+    api.addPart.mockReturnValueOnce(null as never);
+    await expect(call(toolbox(api), "m3e_add_part", { kind: "button" })).rejects.toThrow(/could not be placed/);
+  });
+});
+
+describe("m3e_update_part", () => {
+  it("passes on only the fields it was given", async () => {
+    const api = fakeEditor();
+    await call(toolbox(api), "m3e_update_part", { id: "i1", label: "Done", icon: "check" });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { label: "Done", icon: "check" });
+  });
+
+  it("holds a slider's value inside 0..100", async () => {
+    const api = editorWith(part({ kind: "slider", value: 40 }));
+    const tools = toolbox(api);
+    await call(tools, "m3e_update_part", { id: "i1", value: 140 });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { value: 100 });
+    await call(tools, "m3e_update_part", { id: "i1", value: -5 });
+    expect(api.updatePart).toHaveBeenLastCalledWith("i1", { value: 0 });
+  });
+
+  it("holds a width inside the range and on the step the kind's own slider uses", async () => {
+    const spec = KIND_SPEC.button.size!;
+    const api = editorWith(part());
+    const tools = toolbox(api);
+    await call(tools, "m3e_update_part", { id: "i1", size: 1e6 });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { size: spec.max });
+    await call(tools, "m3e_update_part", { id: "i1", size: 1 });
+    expect(api.updatePart).toHaveBeenLastCalledWith("i1", { size: spec.min });
+    await call(tools, "m3e_update_part", { id: "i1", size: 101 });
+    /* the slider moves in whole steps, so a typed width lands where a dragged one would */
+    expect(api.updatePart).toHaveBeenLastCalledWith("i1", { size: Math.round(101 / spec.step) * spec.step });
+  });
+
+  it("holds the selected destination inside the row it belongs to", async () => {
+    const api = editorWith(part({ kind: "bottomNav", tabs: [{ icon: "home", label: "Home" }, { icon: "search", label: "Search" }] }));
+    const tools = toolbox(api);
+    await call(tools, "m3e_update_part", { id: "i1", selected: 9 });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { selected: 1 });
+    await call(tools, "m3e_update_part", { id: "i1", selected: -3 });
+    expect(api.updatePart).toHaveBeenLastCalledWith("i1", { selected: 0 });
+  });
+
+  it("keeps false and zero, which a truthiness check would drop", async () => {
+    const api = editorWith(part({ kind: "switch", checked: true }));
+    await call(toolbox(api), "m3e_update_part", { id: "i1", checked: false });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { checked: false });
+    const slider = editorWith(part({ kind: "slider", value: 40 }));
+    await call(toolbox(slider), "m3e_update_part", { id: "i1", value: 0 });
+    expect(slider.updatePart).toHaveBeenCalledWith("i1", { value: 0 });
+  });
+
+  it("refuses a field the kind does not carry rather than dropping it silently", async () => {
+    const tools = toolbox(editorWith(part()));
+    /* a button has no on/off state, no progress value and no destinations */
+    await expect(call(tools, "m3e_update_part", { id: "i1", checked: true })).rejects.toThrow(/carries no checked/);
+    await expect(call(tools, "m3e_update_part", { id: "i1", value: 50 })).rejects.toThrow(/carries no value/);
+    await expect(call(tools, "m3e_update_part", { id: "i1", selected: 0 })).rejects.toThrow(/carries no selected/);
+    await expect(call(tools, "m3e_update_part", { id: "i1", supporting: "x" })).rejects.toThrow(/carries no supporting/);
+  });
+
+  it("takes a note on any kind, since that is the author's own sentence", async () => {
+    const api = editorWith(part({ kind: "divider" }));
+    await call(toolbox(api), "m3e_update_part", { id: "i1", note: "separates the two groups" });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { note: "separates the two groups" });
+  });
+
+  it("turns an empty icon into no icon", async () => {
+    const api = fakeEditor();
+    await call(toolbox(api), "m3e_update_part", { id: "i1", icon: "" });
+    expect(api.updatePart).toHaveBeenCalledWith("i1", { icon: null });
+  });
+
+  it("reports no position, because the part did not move", async () => {
+    const updated = (await call(toolbox(fakeEditor()), "m3e_update_part", { id: "i1", label: "Done" })) as { updated: Record<string, unknown> };
+    expect(updated.updated).toMatchObject({ id: "i1", label: "Done" });
+    for (const key of ["x", "y", "w", "h"]) expect(updated.updated).not.toHaveProperty(key);
+  });
+
+  it("refuses a call with nothing to change, and one with no id", async () => {
+    const tools = toolbox(fakeEditor());
+    await expect(call(tools, "m3e_update_part", { id: "i1" })).rejects.toThrow(/at least one field/);
+    await expect(call(tools, "m3e_update_part", { label: "Done" })).rejects.toThrow(/id is required/);
+  });
+
+  it("says so when the id names no part", async () => {
+    const tools = toolbox(fakeEditor());
+    await expect(call(tools, "m3e_update_part", { id: "gone", label: "Done" })).rejects.toThrow(/no part with the id/);
+  });
+});
+
+describe("m3e_delete_part", () => {
+  it("deletes by id and reports what went", async () => {
+    const api = fakeEditor();
+    await expect(call(toolbox(api), "m3e_delete_part", { id: "i1" })).resolves.toEqual({ deleted: "i1" });
+    expect(api.deletePart).toHaveBeenCalledWith("i1");
+  });
+
+  it("explains a refusal instead of reporting a silent success", async () => {
+    const tools = toolbox(fakeEditor());
+    await expect(call(tools, "m3e_delete_part", { id: "locked" })).rejects.toThrow(/no part with the id|locked/);
+    await expect(call(tools, "m3e_delete_part", {})).rejects.toThrow(/id is required/);
+  });
+});
+
+describe("screen tools", () => {
+  it("adds a named screen, and lets the editor name an unnamed one", async () => {
+    const api = fakeEditor();
+    const tools = toolbox(api);
+    await expect(call(tools, "m3e_add_screen", { name: "Profile" })).resolves.toEqual({ added: { id: "f3", name: "Profile" } });
+    expect(api.addScreen).toHaveBeenCalledWith("Profile");
+    await call(tools, "m3e_add_screen");
+    expect(api.addScreen).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("resolves a screen by name before changing it", async () => {
+    const api = fakeEditor();
+    await call(toolbox(api), "m3e_update_screen", { id: "Settings", name: "Preferences", place: "center", note: "Toggles" });
+    expect(api.updateScreen).toHaveBeenCalledWith("f2", { name: "Preferences", place: "center", note: "Toggles" });
+  });
+
+  it("ignores a place it does not know and an empty new name", async () => {
+    const tools = toolbox(fakeEditor());
+    await expect(call(tools, "m3e_update_screen", { id: "f1", place: "sideways" })).rejects.toThrow(/at least one field/);
+    await expect(call(tools, "m3e_update_screen", { id: "f1", name: "  " })).rejects.toThrow(/at least one field/);
+  });
+
+  it("tidies the screen it is pointed at, and the first one by default", async () => {
+    const api = fakeEditor();
+    const tools = toolbox(api);
+    await expect(call(tools, "m3e_tidy_screen", { screen: "f2" })).resolves.toEqual({ screen: { id: "f2", name: "Settings" }, changed: true });
+    await call(tools, "m3e_tidy_screen");
+    expect(api.tidyScreen).toHaveBeenLastCalledWith("f1");
+  });
+
+  it("reports a screen that was already tidy rather than failing", async () => {
+    const api = fakeEditor();
+    api.tidyScreen.mockReturnValueOnce(false);
+    await expect(call(toolbox(api), "m3e_tidy_screen", { screen: "f1" })).resolves.toMatchObject({ changed: false });
+  });
+});
+
+describe("m3e_set_theme", () => {
+  it("applies the scheme and the axes in one call, so one undo takes them both back", async () => {
+    const api = fakeEditor();
+    const result = await call(toolbox(api), "m3e_set_theme", { palette: "teal", dark: true, shape: "full", motion: "expressive" });
+    expect(api.setTheme).toHaveBeenCalledTimes(1);
+    expect(api.setTheme).toHaveBeenCalledWith({ dark: true, shape: "full", motion: "expressive" }, "teal");
+    expect(result).toMatchObject({ palette: "teal", dark: true, shape: "full", motion: "expressive" });
+  });
+
+  it("changes the scheme on its own without touching the axes", async () => {
+    const api = fakeEditor();
+    await call(toolbox(api), "m3e_set_theme", { palette: "green" });
+    expect(api.setTheme).toHaveBeenCalledWith({}, "green");
+  });
+
+  it("takes no scheme or axis it does not offer", async () => {
+    const api = fakeEditor();
+    const tools = toolbox(api);
+    await expect(call(tools, "m3e_set_theme", { palette: "neon" })).rejects.toThrow(/at least one field/);
+    await expect(call(tools, "m3e_set_theme", { shape: "bevelled" })).rejects.toThrow(/at least one field/);
+    await expect(call(tools, "m3e_set_theme", {})).rejects.toThrow(/at least one field/);
+    expect(api.setTheme).not.toHaveBeenCalled();
+  });
+
+  it("turns dark mode back off, which a truthiness check would ignore", async () => {
+    const api = fakeEditor(docOf({ theme: { dark: true } as Theme }));
+    await call(toolbox(api), "m3e_set_theme", { dark: false });
+    expect(api.setTheme).toHaveBeenCalledWith({ dark: false }, undefined);
+  });
+
+  it("reports what it applied, not what the editor still holds one tick later", async () => {
+    /* the editor's own state settles on the next render, so a re-read would answer the old theme */
+    const api = fakeEditor(docOf({ paletteKey: "purple", theme: { dark: false } as Theme }), false);
+    await expect(call(toolbox(api), "m3e_set_theme", { palette: "coral", dark: true, shape: "square" })).resolves.toMatchObject({ palette: "coral", dark: true, shape: "square" });
+    expect(api.doc().paletteKey).toBe("purple");
+  });
+
+  it("leaves the axes it was not given at what the design already had", async () => {
+    const api = fakeEditor(docOf({ theme: { dark: true, motion: "expressive" } as Theme }), false);
+    await expect(call(toolbox(api), "m3e_set_theme", { shape: "square" })).resolves.toMatchObject({ shape: "square", dark: true, motion: "expressive" });
+  });
+});
+
+describe("m3e_set_app_info and m3e_undo", () => {
+  it("sets the name and the brief that head the prompt", async () => {
+    const api = fakeEditor();
+    const tools = toolbox(api);
+    await expect(call(tools, "m3e_set_app_info", { title: "Recipes", brief: "Save and search recipes." })).resolves.toEqual({ title: "Recipes", brief: "Save and search recipes." });
+    await call(tools, "m3e_set_app_info", { brief: "Only the brief." });
+    expect(api.setAppInfo).toHaveBeenLastCalledWith({ title: undefined, brief: "Only the brief." });
+  });
+
+  it("refuses a call that would set neither", async () => {
+    const api = fakeEditor();
+    await expect(call(toolbox(api), "m3e_set_app_info", {})).rejects.toThrow(/title, a brief, or both/);
+    expect(api.setAppInfo).not.toHaveBeenCalled();
+  });
+
+  it("undoes one step per call, the same step the author's undo would", async () => {
+    const api = fakeEditor();
+    await expect(call(toolbox(api), "m3e_undo")).resolves.toEqual({ undone: true });
+    expect(api.undo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/webmcp.ts
+++ b/lib/webmcp.ts
@@ -1,0 +1,616 @@
+﻿import { KIND_TEXT, Lang, t } from "./i18n";
+import { barSlotOf, bodyRect, isBodyRun } from "./tidy";
+import {
+  CATEGORIES,
+  CONTRASTS,
+  Contrast,
+  Doc,
+  FONTS,
+  FULL_WIDTH,
+  FontKey,
+  Frame,
+  Group,
+  Item,
+  KIND_ORDER,
+  KIND_SPEC,
+  Kind,
+  MotionScheme,
+  PALETTES,
+  PHONE_H,
+  PHONE_MARGIN,
+  PHONE_W,
+  PLACES,
+  Place,
+  ShapeScale,
+  SHAPES,
+  Theme,
+  VARIANTS,
+  Variant,
+  carryItemSize,
+  clamp,
+  fitHeight,
+  frameRect,
+  frameSizeOf,
+  groupBounds,
+  groupsInFrame,
+  layoutOf,
+  normalizeTheme,
+  sizeOf,
+} from "./tokens";
+
+/* WebMCP: the editor hands its own operations to the browser's agent as tools, so a
+ * model can sketch a screen the way a person does. Every tool goes through the same
+ * function the UI calls, which keeps one undo stack and one set of rules — nothing
+ * here writes to the document on its own.
+ *
+ * Spec: https://webmachinelearning.github.io/webmcp/ (W3C Web Machine Learning CG).
+ * The API is `document.modelContext`, is only exposed in a secure context, and needs
+ * an origin-keyed agent cluster; where any of that is missing the editor carries on
+ * exactly as before. */
+
+/* ---------- the shape of the API, until the DOM lib declares it ---------- */
+
+/** Hints an agent can use before it calls: whether the tool only reads, whether its
+ *  result is author content rather than our own words, and whether it changes the design. */
+export type ToolAnnotations = {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+  consequentialHint?: boolean;
+};
+
+/** the subset of JSON Schema the tools use: one object of named, typed fields */
+export type ToolSchema = {
+  type: "object";
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: false;
+};
+
+export type ToolInput = Record<string, unknown>;
+
+export type WebMcpTool = {
+  name: string;
+  /** shown by the browser in its own UI, so it follows the editor's language */
+  title: string;
+  description: string;
+  inputSchema?: ToolSchema;
+  annotations?: ToolAnnotations;
+  execute: (input: ToolInput, options?: { signal: AbortSignal }) => unknown | Promise<unknown>;
+};
+
+/** `exposedTo` widens a tool to other origins in the page's tree. The editor never passes
+ *  it: the default is same-origin, which is all a page with no iframes and no backend wants. */
+export type RegisterToolOptions = { signal?: AbortSignal; exposedTo?: string[] };
+
+export type ModelContext = {
+  registerTool: (tool: WebMcpTool, options?: RegisterToolOptions) => Promise<void>;
+};
+
+type MaybeModelContext = Document & { modelContext?: ModelContext };
+
+/** The page's model context, or null in a browser that does not offer WebMCP. */
+export function getModelContext(target?: Document): ModelContext | null {
+  const host = (target ?? (typeof document === "undefined" ? undefined : document)) as MaybeModelContext | undefined;
+  const ctx = host?.modelContext;
+  return ctx && typeof ctx.registerTool === "function" ? ctx : null;
+}
+
+/** the names the spec accepts: 1..128 of ASCII alphanumeric, underscore, hyphen, full stop */
+export const isToolName = (name: string) => /^[A-Za-z0-9_.-]{1,128}$/.test(name);
+
+/** A tool that answers with a promise even when it refuses straight away, so the reason
+ *  reaches the agent as a rejection whatever the implementation does with a plain throw. */
+const settled = (tool: WebMcpTool): WebMcpTool => ({ ...tool, execute: async (input, options) => tool.execute(input, options) });
+
+/** Registers every tool, and reports the names that took. A name the browser turns
+ *  down, or a page that has lost the "tools" permission, must not cost us the rest
+ *  of the toolbox, so each registration is tried on its own. */
+export async function registerTools(tools: WebMcpTool[], ctx: ModelContext, signal?: AbortSignal): Promise<string[]> {
+  const done: string[] = [];
+  for (const tool of tools) {
+    if (signal?.aborted) break;
+    /* a name the spec would refuse comes back as a bare rejection, so it is caught here where
+     * the reason can be said out loud */
+    if (!isToolName(tool.name)) {
+      console.warn(`m3e-canvas: "${tool.name}" is not a name WebMCP accepts, so the tool was not offered`);
+      continue;
+    }
+    try {
+      await ctx.registerTool(settled(tool), signal ? { signal } : undefined);
+      done.push(tool.name);
+    } catch {
+      /* left unregistered; the editor works the same either way */
+    }
+  }
+  return done;
+}
+
+/* ---------- the switch, stored in this browser like the rest of the settings ---------- */
+
+const STORE_KEY = "m3e:webmcp";
+
+/** Tools are offered unless this browser was told not to; only "off" is stored. */
+export function loadWebMcpEnabled(): boolean {
+  try {
+    return localStorage.getItem(STORE_KEY) !== "off";
+  } catch {
+    return true;
+  }
+}
+
+export function saveWebMcpEnabled(on: boolean) {
+  try {
+    if (on) localStorage.removeItem(STORE_KEY);
+    else localStorage.setItem(STORE_KEY, "off");
+  } catch {}
+}
+
+/* ---------- where a part an agent asks for lands ---------- */
+
+/** A part sized for the screen it is going on: a bar spans the slot left by the rails,
+ *  anything else is kept no taller than the screen — the same two rules the drop applies. */
+export function agentSize(item: Item, frame: Frame, groups: Group[], frames: Frame[], widths: Record<string, number>): Item {
+  const { w, h } = frameSizeOf(frame);
+  if (!FULL_WIDTH.includes(item.kind)) return fitHeight(item, h);
+  const slot = barSlotOf(groups, frame, frames, widths);
+  return carryItemSize(item, { w: PHONE_W, h: PHONE_H }, { w: slot.w, h });
+}
+
+/** Where a part an agent asks for goes. Bars and rails take the edge they belong to;
+ *  everything else stacks down the body on the layout margin, under the runs already
+ *  filling it — the same split Tidy reads, so a rail shapes the body instead of being
+ *  stacked under. A body with no room left stacks on, which the author can see and
+ *  `m3e_tidy_screen` resolves. */
+export function agentSlot(item: Item, frame: Frame, groups: Group[], frames: Frame[], widths: Record<string, number>): { x: number; y: number } {
+  const screen = frameRect(frame);
+  const slot = barSlotOf(groups, frame, frames, widths);
+  const size = sizeOf(item, widths);
+  if (item.kind === "topAppBar") return { x: Math.round(slot.x), y: Math.round(screen.t) };
+  if (item.kind === "bottomNav") return { x: Math.round(slot.x), y: Math.round(screen.b - size.h) };
+  if (item.kind === "navRail") return { x: Math.round(screen.l), y: Math.round(screen.t) };
+  const body = bodyRect(groups, frame, frames, widths);
+  let y = body.t;
+  for (const g of groupsInFrame(groups, frame, frames, widths)) {
+    if (!isBodyRun(g)) continue;
+    y = Math.max(y, groupBounds(g, widths).b + PHONE_MARGIN);
+  }
+  /* the part keeps its centre on the screen, so it still belongs to this frame */
+  const top = Math.min(y, screen.b - size.h / 2);
+  return { x: Math.round(item.kind === "tabs" ? slot.x : body.l), y: Math.round(Math.max(body.t, top)) };
+}
+
+/* ---------- what the editor lets a tool do ---------- */
+
+export type AddPartSpec = {
+  kind: Kind;
+  /** a screen by id or by name; the first screen when left out */
+  screen?: string;
+  label?: string;
+  supporting?: string;
+  icon?: string | null;
+  variant?: Variant;
+};
+
+/** The editor's own operations, named so the tools never reach into React state.
+ *  A mutation returns what it changed, or null / false when it found nothing to change. */
+export type EditorToolApi = {
+  doc: () => Doc;
+  /** measured widths of the kinds that size to their text, as `sizeOf` wants them */
+  widths: () => Record<string, number>;
+  lang: () => Lang;
+  /** the vibe-coding prompt: the whole design, or one screen */
+  prompt: (frameId?: string) => string;
+  /** the part as it landed, the screen it went on, and the box it took there */
+  addPart: (spec: AddPartSpec) => { item: Item; frame: Frame; at: PartBox } | null;
+  updatePart: (id: string, patch: Partial<Item>) => Item | null;
+  deletePart: (id: string) => boolean;
+  addScreen: (name?: string) => Frame;
+  updateScreen: (id: string, patch: Partial<Frame>) => Frame | null;
+  /** false when the screen is empty or already tidy */
+  tidyScreen: (id: string) => boolean;
+  /** the theme axes and, when given, the colour scheme, as one undo step */
+  setTheme: (patch: Partial<Theme>, palette?: string) => void;
+  setAppInfo: (patch: { title?: string; brief?: string }) => void;
+  undo: () => void;
+};
+
+/* ---------- reading the arguments an agent sends ---------- */
+
+const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+const num = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+const bool = (v: unknown): boolean | undefined => (typeof v === "boolean" ? v : undefined);
+const oneOf = <T extends string>(v: unknown, allowed: readonly T[]): T | undefined => (typeof v === "string" && (allowed as readonly string[]).includes(v) ? (v as T) : undefined);
+
+/** the value of a field the tool cannot work without */
+function required(input: ToolInput, key: string): string {
+  const v = str(input[key]);
+  if (v === undefined || v === "") throw new Error(`${key} is required`);
+  return v;
+}
+
+const kindOf = (v: unknown): Kind => {
+  const kind = oneOf(v, KIND_ORDER);
+  if (!kind) throw new Error(`kind must be one of: ${KIND_ORDER.join(", ")}`);
+  return kind;
+};
+
+/* ---------- what each kind carries ---------- */
+
+/** the fields the tools can set on a part, in the order the schemas list them */
+export const PART_FIELDS = ["label", "supporting", "icon", "variant", "size", "checked", "value", "selected"] as const;
+
+/** Whether a kind carries a field at all. `m3e_list_part_kinds` publishes this and the
+ *  writing tools enforce it, so what an agent is told and what it may do cannot drift. */
+export function accepts(kind: Kind, field: string): boolean {
+  const s = KIND_SPEC[kind];
+  switch (field) {
+    case "label":
+      return s.hasLabel;
+    case "supporting":
+      return s.hasSupporting;
+    case "icon":
+      return s.hasIcon;
+    case "variant":
+      return s.hasVariant;
+    case "size":
+      return !!s.size;
+    case "checked":
+      return !!s.hasChecked;
+    case "value":
+      return !!s.hasValue;
+    case "selected":
+      return !!s.hasTabs;
+    /* a note is the author's own sentence about a part; every kind takes one */
+    default:
+      return true;
+  }
+}
+
+const refuse = (kind: Kind, field: string): never => {
+  throw new Error(`a ${kind} carries no ${field}; m3e_list_part_kinds names the fields each kind accepts`);
+};
+
+/** the part an id names, wherever on the canvas it stands */
+export const findPart = (doc: Doc, id: string): Item | undefined => doc.groups.flatMap((g) => g.items).find((it) => it.id === id);
+
+/** The edit an agent asked for, refused when the kind carries no such field and held inside
+ *  the range the inspector's own control allows, so a tool cannot reach a value a hand cannot. */
+export function itemPatch(item: Item, input: ToolInput): Partial<Item> {
+  const spec = KIND_SPEC[item.kind];
+  const patch: Partial<Item> = {};
+  const take = (field: string) => accepts(item.kind, field) || refuse(item.kind, field);
+  const label = str(input.label);
+  const supporting = str(input.supporting);
+  const icon = str(input.icon);
+  const variant = oneOf(input.variant, VARIANT_KEYS);
+  const size = num(input.size);
+  const checked = bool(input.checked);
+  const value = num(input.value);
+  const selected = num(input.selected);
+  const note = str(input.note);
+  if (label !== undefined && take("label")) patch.label = label;
+  if (supporting !== undefined && take("supporting")) patch.supporting = supporting;
+  if (icon !== undefined && take("icon")) patch.icon = icon === "" ? null : icon;
+  if (variant !== undefined && take("variant")) patch.variant = variant;
+  if (size !== undefined && take("size") && spec.size) {
+    /* the slider's own range and step, so a typed value lands where a dragged one would */
+    const stepped = Math.round(size / spec.size.step) * spec.size.step;
+    patch.size = clamp(stepped, spec.size.min, spec.size.max);
+  }
+  if (checked !== undefined && take("checked")) patch.checked = checked;
+  if (value !== undefined && take("value")) patch.value = clamp(Math.round(value), 0, 100);
+  if (selected !== undefined && take("selected")) patch.selected = clamp(Math.round(selected), 0, Math.max(0, (item.tabs?.length ?? 1) - 1));
+  if (note !== undefined) patch.note = note;
+  if (!Object.keys(patch).length) throw new Error("pass at least one field to change");
+  return patch;
+}
+
+/* ---------- what the tools report back ---------- */
+
+export type PartBox = { x: number; y: number; w: number; h: number };
+
+/** A part as an agent reads it: the fields it can set, and where it sits when that is known.
+ *  A tool that did not move the part reports no box rather than an invented one. */
+export function describePart(item: Item, at?: PartBox) {
+  return {
+    id: item.id,
+    kind: item.kind,
+    label: item.label || undefined,
+    supporting: item.supporting || undefined,
+    icon: item.icon ?? undefined,
+    variant: accepts(item.kind, "variant") ? item.variant : undefined,
+    size: item.size,
+    checked: item.checked,
+    value: item.value,
+    selected: item.selected,
+    tabs: item.tabs?.map((tab) => tab.label),
+    note: item.note || undefined,
+    ...(at ? { x: Math.round(at.x), y: Math.round(at.y), w: Math.round(at.w), h: Math.round(at.h) } : {}),
+  };
+}
+
+/** The document as an agent reads it: the app, the theme, and each screen with its parts. */
+export function describeDoc(doc: Doc, widths: Record<string, number>) {
+  const theme = normalizeTheme(doc.theme);
+  const parts = (frame: Frame) =>
+    groupsInFrame(doc.groups, frame, doc.frames, widths).flatMap((g) => layoutOf(g, widths).map((pl) => ({ ...describePart(pl.item, pl), locked: g.locked || undefined })));
+  return {
+    app: { title: doc.title, brief: doc.brief, platform: doc.platform ?? "android", canvas: doc.frame },
+    theme: { palette: doc.paletteKey, dark: theme.dark, contrast: theme.contrast, shape: theme.shape, font: theme.font, motion: theme.motion, emphasized: theme.emphasized },
+    screens: doc.frames.map((f) => {
+      const { w, h } = frameSizeOf(f);
+      return { id: f.id, name: f.name, w, h, place: f.place ?? "top", note: f.note || undefined, parts: parts(f) };
+    }),
+  };
+}
+
+/* ---------- the tools ---------- */
+
+const PALETTE_KEYS = PALETTES.map((p) => p.key);
+const VARIANT_KEYS = VARIANTS.map((v) => v.key);
+const PLACE_KEYS = PLACES.map((p) => p.key);
+const SHAPE_KEYS = SHAPES.map((s) => s.key);
+const FONT_KEYS = FONTS.map((f) => f.key);
+const CONTRAST_KEYS = CONTRASTS.map((c) => c.key);
+const MOTION_KEYS: MotionScheme[] = ["standard", "expressive"];
+
+const field = (type: string, description: string, extra: Record<string, unknown> = {}) => ({ type, description, ...extra });
+const schema = (properties: Record<string, unknown>, required?: string[]): ToolSchema => ({ type: "object", properties, required, additionalProperties: false });
+
+/** the screen an argument names, by id or by name; the first screen when it names none */
+function screenOf(doc: Doc, name?: string): Frame {
+  if (!doc.frames.length) throw new Error("the design has no screens yet; call m3e_add_screen first");
+  if (!name) return doc.frames[0];
+  const found = doc.frames.find((f) => f.id === name) ?? doc.frames.find((f) => f.name === name);
+  if (!found) throw new Error(`no screen with the id or name "${name}"`);
+  return found;
+}
+
+/** Every operation the editor exposes. Descriptions are the agent's only guide, so they
+ *  name the vocabulary (kinds, palettes, tokens) rather than describing the UI. */
+export function editorTools(editor: () => EditorToolApi): WebMcpTool[] {
+  /* read through the getter on every call, so a toolbox the browser took once still reaches
+   * the editor as it is now and never a closure frozen at registration */
+  const api = () => editor();
+  const lang = () => api().lang();
+  const doc = () => api().doc();
+
+  return [
+    {
+      name: "m3e_list_part_kinds",
+      title: t("mcpToolListKinds", lang()),
+      description:
+        "List every Material 3 Expressive part this editor can draw, with its category and the fields it accepts. Call this before m3e_add_part so the kind you ask for exists.",
+      annotations: { readOnlyHint: true },
+      execute: () => ({
+        categories: CATEGORIES.map((c) => ({ key: c.key, label: c.label })),
+        kinds: KIND_ORDER.map((kind) => {
+          const s = KIND_SPEC[kind];
+          return {
+            kind,
+            label: s.label,
+            noun: KIND_TEXT[lang()][kind]?.noun ?? s.noun,
+            category: s.category,
+            accepts: PART_FIELDS.filter((f) => accepts(kind, f)),
+            size: s.size ? { min: s.size.min, max: s.size.max, step: s.size.step } : undefined,
+            variants: s.hasVariant ? VARIANT_KEYS : undefined,
+          };
+        }),
+      }),
+    },
+    {
+      name: "m3e_get_document",
+      title: t("mcpToolGetDocument", lang()),
+      description:
+        "Read the sketch as it stands: the app name and brief, the theme, and every screen with the parts on it and their ids and positions in dp. Use the ids it returns with m3e_update_part and m3e_delete_part.",
+      /* labels, notes and a design opened from a shared link are the author's words, not ours */
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: () => describeDoc(doc(), api().widths()),
+    },
+    {
+      name: "m3e_get_prompt",
+      title: t("mcpToolGetPrompt", lang()),
+      description:
+        "Get the vibe-coding prompt this sketch generates: the Material 3 Expressive specification of the screens, ready to hand to a coding agent. Pass a screen id to get that screen alone.",
+      inputSchema: schema({ screen: field("string", "A screen id or name. All screens when left out.") }),
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: (input) => {
+        const name = str(input.screen);
+        return { prompt: api().prompt(name ? screenOf(doc(), name).id : undefined) };
+      },
+    },
+    {
+      name: "m3e_add_part",
+      title: t("mcpToolAddPart", lang()),
+      description:
+        "Put one Material 3 Expressive part on a screen. Bars and rails go to the edge they belong to; anything else stacks down the body under what is already there. Follow a run of these with m3e_tidy_screen to lay the screen out.",
+      inputSchema: schema(
+        {
+          kind: field("string", "The part to add.", { enum: KIND_ORDER }),
+          screen: field("string", "A screen id or name. The first screen when left out."),
+          label: field("string", "Headline or button text. The part's default when left out."),
+          supporting: field("string", "Second line, for the kinds that show one."),
+          icon: field("string", "A Material Symbols name, such as search or favorite. Pass an empty string for no icon."),
+          variant: field("string", "How much emphasis the part carries.", { enum: VARIANT_KEYS }),
+        },
+        ["kind"],
+      ),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const kind = kindOf(input.kind);
+        const icon = str(input.icon);
+        const take = (f: string, v: unknown) => (v === undefined ? undefined : accepts(kind, f) ? v : refuse(kind, f));
+        const added = api().addPart({
+          kind,
+          screen: str(input.screen),
+          label: take("label", str(input.label)) as string | undefined,
+          supporting: take("supporting", str(input.supporting)) as string | undefined,
+          icon: take("icon", icon === undefined ? undefined : icon === "" ? null : icon) as string | null | undefined,
+          variant: take("variant", oneOf(input.variant, VARIANT_KEYS)) as Variant | undefined,
+        });
+        if (!added) throw new Error("the part could not be placed; check the screen argument");
+        return { added: describePart(added.item, added.at), screen: { id: added.frame.id, name: added.frame.name } };
+      },
+    },
+    {
+      name: "m3e_update_part",
+      title: t("mcpToolUpdatePart", lang()),
+      description: "Change a part already on the canvas. Only the fields you pass are touched; m3e_get_document lists the ids and which fields each kind accepts.",
+      inputSchema: schema(
+        {
+          id: field("string", "The part id from m3e_get_document."),
+          label: field("string", "Headline or button text."),
+          supporting: field("string", "Second line."),
+          icon: field("string", "A Material Symbols name. An empty string removes the icon."),
+          variant: field("string", "How much emphasis the part carries.", { enum: VARIANT_KEYS }),
+          size: field("number", "Width in dp, or the type size in dp for a text. Held inside the range m3e_list_part_kinds reports for the kind."),
+          checked: field("boolean", "On or off, for switches, checkboxes and chips."),
+          value: field("number", "0 to 100, for sliders and determinate progress."),
+          selected: field("number", "Index of the selected destination, for navigation bars, rails and tab rows."),
+          note: field("string", "What this part does, in the author's words. It goes into the generated prompt."),
+        },
+        ["id"],
+      ),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const id = required(input, "id");
+        const before = findPart(doc(), id);
+        if (!before) throw new Error(`no part with the id "${id}"`);
+        const item = api().updatePart(id, itemPatch(before, input));
+        if (!item) throw new Error(`no part with the id "${id}"`);
+        /* the part did not move, so no box is reported; m3e_get_document has the positions */
+        return { updated: describePart(item) };
+      },
+    },
+    {
+      name: "m3e_delete_part",
+      title: t("mcpToolDeletePart", lang()),
+      description: "Remove one part from the canvas. Undoable with m3e_undo.",
+      inputSchema: schema({ id: field("string", "The part id from m3e_get_document.") }, ["id"]),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const id = required(input, "id");
+        if (!api().deletePart(id)) throw new Error(`no part with the id "${id}", or it belongs to a locked group`);
+        return { deleted: id };
+      },
+    },
+    {
+      name: "m3e_add_screen",
+      title: t("mcpToolAddScreen", lang()),
+      description: "Add an empty screen to the right of the others. Returns its id, for m3e_add_part.",
+      inputSchema: schema({ name: field("string", "What the screen is called, such as Home or Settings.") }),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const frame = api().addScreen(str(input.name));
+        return { added: { id: frame.id, name: frame.name } };
+      },
+    },
+    {
+      name: "m3e_update_screen",
+      title: t("mcpToolUpdateScreen", lang()),
+      description: "Rename a screen, say what it is for, or choose how m3e_tidy_screen stacks its body.",
+      inputSchema: schema(
+        {
+          id: field("string", "The screen id or name."),
+          name: field("string", "The new name."),
+          note: field("string", "What this screen is for, in the author's words. It goes into the generated prompt."),
+          place: field("string", "Where the body sits between the bars.", { enum: PLACE_KEYS }),
+        },
+        ["id"],
+      ),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const patch: Partial<Frame> = {};
+        const name = str(input.name)?.trim();
+        const note = str(input.note);
+        const place = oneOf(input.place, PLACE_KEYS as readonly Place[]);
+        /* a screen with no name reads as a bug on the canvas, so a blank one is no change */
+        if (name) patch.name = name;
+        if (note !== undefined) patch.note = note;
+        if (place !== undefined) patch.place = place;
+        if (!Object.keys(patch).length) throw new Error("pass at least one field to change");
+        const frame = api().updateScreen(screenOf(doc(), required(input, "id")).id, patch);
+        if (!frame) throw new Error(`no screen with the id or name "${String(input.id)}"`);
+        return { updated: { id: frame.id, name: frame.name, note: frame.note || undefined, place: frame.place ?? "top" } };
+      },
+    },
+    {
+      name: "m3e_tidy_screen",
+      title: t("mcpToolTidyScreen", lang()),
+      description:
+        "Lay one screen out by the editor's own rules: parts of one family fuse into a connected run, bars stick to their edges, and the rest stacks on the 16dp layout margins. Call this after adding parts.",
+      inputSchema: schema({ screen: field("string", "A screen id or name. The first screen when left out.") }, []),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const frame = screenOf(doc(), str(input.screen));
+        return { screen: { id: frame.id, name: frame.name }, changed: api().tidyScreen(frame.id) };
+      },
+    },
+    {
+      name: "m3e_set_theme",
+      title: t("mcpToolSetTheme", lang()),
+      description:
+        "Set the design's colour scheme and the Material 3 Expressive theme axes. Only the fields you pass are touched. The parts redraw from the scheme's tokens, so they stay correct in dark mode.",
+      inputSchema: schema({
+        palette: field("string", "The colour scheme.", { enum: PALETTE_KEYS }),
+        dark: field("boolean", "Draw the canvas in dark mode."),
+        contrast: field("string", "Contrast level.", { enum: CONTRAST_KEYS }),
+        shape: field("string", "The corner scale the parts take.", { enum: SHAPE_KEYS }),
+        font: field("string", "The type family.", { enum: FONT_KEYS }),
+        motion: field("string", "Standard easing, or the springier expressive scheme.", { enum: MOTION_KEYS }),
+        emphasized: field("boolean", "Headings and labels take the heavier expressive styles."),
+      }),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const palette = oneOf(input.palette, PALETTE_KEYS);
+        const patch: Partial<Theme> = {};
+        const dark = bool(input.dark);
+        const emphasized = bool(input.emphasized);
+        const contrast = oneOf(input.contrast, CONTRAST_KEYS as readonly Contrast[]);
+        const shape = oneOf(input.shape, SHAPE_KEYS as readonly ShapeScale[]);
+        const font = oneOf(input.font, FONT_KEYS as readonly FontKey[]);
+        const motion = oneOf(input.motion, MOTION_KEYS);
+        if (dark !== undefined) patch.dark = dark;
+        if (emphasized !== undefined) patch.emphasized = emphasized;
+        if (contrast !== undefined) patch.contrast = contrast;
+        if (shape !== undefined) patch.shape = shape;
+        if (font !== undefined) patch.font = font;
+        if (motion !== undefined) patch.motion = motion;
+        if (!palette && !Object.keys(patch).length) throw new Error("pass at least one field to change");
+        /* one call is one undo step, so the scheme and the axes are applied together */
+        api().setTheme(patch, palette);
+        /* what was applied, not a re-read: the editor's own state settles on the next render */
+        return { ...normalizeTheme({ ...normalizeTheme(doc().theme), ...patch }), palette: palette ?? doc().paletteKey };
+      },
+    },
+    {
+      name: "m3e_set_app_info",
+      title: t("mcpToolSetAppInfo", lang()),
+      description: "Name the app and say what it does. Both go at the head of the generated prompt, so they shape what a coding agent builds.",
+      inputSchema: schema({
+        title: field("string", "The app's name."),
+        brief: field("string", "A sentence or two on what the app is for."),
+      }),
+      annotations: { consequentialHint: true },
+      execute: (input) => {
+        const title = str(input.title);
+        const brief = str(input.brief);
+        if (title === undefined && brief === undefined) throw new Error("pass a title, a brief, or both");
+        api().setAppInfo({ title, brief });
+        /* what was applied, not a re-read: the editor's own state settles on the next render */
+        const was = doc();
+        return { title: title ?? was.title, brief: brief ?? was.brief };
+      },
+    },
+    {
+      name: "m3e_undo",
+      title: t("mcpToolUndo", lang()),
+      description: "Undo the last change, whether the author or a tool made it. One step per call.",
+      annotations: { consequentialHint: true },
+      execute: () => {
+        api().undo();
+        return { undone: true };
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## What and why

No issue yet — happy to move this to one if you'd rather settle the shape first,
since CONTRIBUTING asks for that on changes this size. Open questions at the bottom.

Sketching is direct manipulation today, and the AI path is one-shot: a model drafts
a whole document, and the author keeps or undoes it. There's no way for an agent to
work on a sketch already in progress — add one part, look at it, rename a screen,
tidy it.

[WebMCP](https://webmachinelearning.github.io/webmcp/) is a W3C Web ML CG draft for
exactly that: a page registers its own functions as tools on `document.modelContext`
and the browser's agent calls them. Chrome ships it behind a flag.

This puts twelve of the editor's operations up as tools — three that only read (the
part vocabulary, the document, the generated prompt) and nine that write (add, change
and delete a part; add, change and tidy a screen; the theme; the app details; undo).

**Every tool calls the same function the UI calls.** That was the constraint: an
agent's change snapshots like the author's and is one `Ctrl+Z` away, and the
locked-group rule holds. So that a second set of rules can't drift from the first:

- `patchItem` was extracted from `patchSelected`, and `withoutItems` from
  `deleteSelected`, rather than copied. Neither changes behavior for the keyboard or
  inspector paths.
- Placement reuses `barSlotOf`, `bodyRect`, `carryItemSize` and `pullInto`, so a bar
  spans only the room a rail leaves it and nothing lands off-screen.
- `lib/tidy.ts` now exports `isBodyRun` (first commit, no behavior change). Placing a
  part needs to know what shapes the body versus what fills it, and guessing that
  geometrically gets a navigation rail wrong — it spans the body's full height, so it
  reads as body content.
- Per-kind validation is shared with what `m3e_list_part_kinds` advertises, so a field
  a kind doesn't carry is refused instead of written and silently dropped, and a width
  lands on the range and step the inspector's slider uses.

Tool `description` is English since only the agent reads it. Tool `title` is what the
browser shows in its own UI, so it goes through `t()` in all four languages.

Tools go up where the browser implements the API and the editor is writable; a switch
in the AI tab turns them off. A browser without the API registers nothing and says so.

Two commits: the `tidy.ts` export first (skimmable, behavior-preserving), then the
feature.

## How I checked it

- [x] `npm run typecheck` passes

- [x] `npm test` passes — 737 tests, 74 new in `lib/webmcp.test.ts`

- [x] `npm run build` passes

- [x] New or changed UI strings and prompt text exist in Japanese, English, Chinese and Korean

- [ ] Tried it in the editor (and on a phone, if the change touches the phone editor)

On that last box, to be straight about it: the tool logic is covered by unit tests
against a stubbed editor, including the placement cases that bit me during review — a
rail on the screen, a full body, a bar beside a rail. What I have **not** done is
drive it end to end from a real browser agent.

There's also a deployment catch worth knowing before this ships. The spec requires an
origin-keyed agent cluster, which comes from the `Origin-Agent-Cluster: ?1` header. A
static export can't send headers, so on GitHub Pages registration will likely fail and
the panel reads "0 tools offered" — no error, just nothing offered. In practice the
feature lives in `npm run dev`, or behind a host that can set the header. If that makes
it not worth shipping yet, I'd rather hear it now.

## Screenshots

The only visual change is a new section at the foot of the AI tab: a switch, a line of
explanation, and a status line reporting how many tools are offered. Parts, canvas and
prompt are untouched.

<!-- screenshot of the AI tab goes here -->

## Open questions

1. **Default on or off?** It's opt-out today. The tools only mutate the local sketch,
   there's no network egress or credential surface, and every change is undoable — but
   the author never opts in. Opt-in is the more conservative read of the spec's
   user-control framing.
2. **Is the AI tab the right home?** It avoids inventing new chrome, but that tab is
   provider settings for "Write with AI", and this is a different thing.
3. **Tool surface.** Twelve felt like the smallest set that can actually build a screen.
   `m3e_set_theme` and `m3e_undo` are what I'd cut first.
4. **Placement.** Bars and rails take their edge, everything else stacks down the body,
   and the agent is told to call `m3e_tidy_screen`. Tidying automatically after every add
   would take that decision away from the author.

Happy to rework any of these.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers twelve of the editor's operations as WebMCP tools, so a browser's agent can work on a sketch in progress — add parts, tidy screens, change the theme — instead of only drafting a whole document. Every tool calls the same function the UI calls, so agent changes land on the author's undo stack and the locked-group rule holds.

- Three tools only read (part vocabulary, document, generated prompt); nine write (add/change/delete a part, add/change/tidy a screen, theme, app details, undo).
- `patchItem` and `withoutItems` were extracted from `patchSelected` and `deleteSelected`; neither path changes behavior for the keyboard or inspector.
- Placement reuses `barSlotOf`, `bodyRect`, `carryItemSize`, and `pullInto`, and `lib/tidy.ts` now exports `isBodyRun` so placing a part reads the same body-versus-anchored split Tidy does.
- Per-kind validation is shared with `m3e_list_part_kinds`, so a field a kind does not carry is refused and widths land on the inspector slider's range and step.
- Descriptions are English since only the agent reads them; titles go through `t()` in all four languages.
- A switch in the AI tab turns the tools off (default on); browsers without the API register nothing and say so.

**Rollout**
- WebMCP requires the `Origin-Agent-Cluster: ?1` header, so static hosts like GitHub Pages will offer no tools; the feature works in `npm run dev` or behind a host that sets the header.

<sup>Written for commit b3dcdef5022ae8c318c1943a1db8ce47fa69880c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

