### PR TITLE
Keep the selection ring above the next part in a connected run

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3073,7 +3073,7 @@ export default function Page() {
       const instantG = instantRef.current.has(g.id);
       const allOn = g.items.every((it) => selectedSet.has(it.id));
       const corners = freeRadii(g, widths);
-      /* hidden runs are connected too: only their members may lift above siblings when selected */
+      /* Hidden runs need the same compact selection ring as connected groups. */
       const runIds = new Set(
         explodeGroup(g, widths)
           .filter((r) => r.items.length > 1)
@@ -3085,8 +3085,7 @@ export default function Page() {
           initial={false}
           animate={{ x: g.x - ox, y: g.y - oy }}
           transition={instantG ? INSTANT : OPEN}
-          /* keep any selection lift inside the group, so canvas-wide layer order is preserved */
-          style={{ position: "absolute", left: 0, top: 0, zIndex: modalRail ? 2 : undefined, isolation: "isolate" }}
+          style={{ position: "absolute", left: 0, top: 0, zIndex: modalRail ? 2 : undefined }}
         >
           {layoutOf(g, widths).map((pl) => (
             <div key={pl.item.id} style={{ position: "absolute", left: pl.x - g.x, top: pl.y - g.y }}>
@@ -3155,8 +3154,6 @@ export default function Page() {
           flexDirection: g.axis === "x" ? "row" : "column",
           alignItems: g.axis === "x" ? "center" : "stretch",
           gap: GAP,
-          /* keep any selection lift inside the run, so canvas-wide layer order is preserved */
-          isolation: "isolate",
         }}
       >
         {cells.map((c, r) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3073,13 +3073,20 @@ export default function Page() {
       const instantG = instantRef.current.has(g.id);
       const allOn = g.items.every((it) => selectedSet.has(it.id));
       const corners = freeRadii(g, widths);
+      /* hidden runs are connected too: only their members may lift above siblings when selected */
+      const runIds = new Set(
+        explodeGroup(g, widths)
+          .filter((r) => r.items.length > 1)
+          .flatMap((r) => r.items.map((it) => it.id)),
+      );
       return (
         <motion.div
           key={g.id}
           initial={false}
           animate={{ x: g.x - ox, y: g.y - oy }}
           transition={instantG ? INSTANT : OPEN}
-          style={{ position: "absolute", left: 0, top: 0, zIndex: modalRail ? 2 : undefined }}
+          /* keep any selection lift inside the group, so canvas-wide layer order is preserved */
+          style={{ position: "absolute", left: 0, top: 0, zIndex: modalRail ? 2 : undefined, isolation: "isolate" }}
         >
           {layoutOf(g, widths).map((pl) => (
             <div key={pl.item.id} style={{ position: "absolute", left: pl.x - g.x, top: pl.y - g.y }}>
@@ -3090,6 +3097,7 @@ export default function Page() {
                 radii={corners.get(pl.item.id)}
                 pressed={false}
                 selected={selectedSet.has(pl.item.id)}
+                inRun={runIds.has(pl.item.id)}
                 interactive={!handMode}
                 onPointerDown={(e) => onItemPointerDown(e, g, pl.index, pl.item)}
               />
@@ -3147,6 +3155,8 @@ export default function Page() {
           flexDirection: g.axis === "x" ? "row" : "column",
           alignItems: g.axis === "x" ? "center" : "stretch",
           gap: GAP,
+          /* keep any selection lift inside the run, so canvas-wide layer order is preserved */
+          isolation: "isolate",
         }}
       >
         {cells.map((c, r) => {
@@ -3190,6 +3200,7 @@ export default function Page() {
               radii={radii}
               pressed={pressedId === c.item.id}
               selected={selectedSet.has(c.item.id)}
+              inRun={g.items.length > 1}
               interactive={!handMode}
               onPointerDown={(e) => onItemPointerDown(e, g, c.index, c.item)}
             />

--- a/components/M3Node.test.tsx
+++ b/components/M3Node.test.tsx
@@ -1,0 +1,24 @@
+import { expect, it, vi } from "vitest";
+import { GAP, PALETTES } from "../lib/tokens";
+import { M3Node } from "./M3Node";
+
+vi.mock("motion/react", () => ({ motion: { div: "div" }, useReducedMotion: () => false }));
+vi.mock("@/lib/tokens", () => import("../lib/tokens"));
+vi.mock("@/lib/i18n", () => ({ t: vi.fn(), useLang: () => "en" }));
+vi.mock("@/lib/theme", () => ({ useTheme: () => "light" }));
+vi.mock("@/lib/color", () => import("../lib/color"));
+vi.mock("./Loading", () => ({ CircularProgress: "div", LinearProgress: "div", LoadingIndicator: "div" }));
+
+it("keeps adjacent selected run rings within the gap without raising their bodies", () => {
+  for (const selected of [false, true]) {
+    const node = (inRun: boolean) => M3Node({
+      item: { id: "row", kind: "button", label: "Row", icon: "", variant: "filled" },
+      palette: PALETTES[0], widths: {}, selected, inRun,
+    });
+    const style = node(true).props.style;
+    // Neither horizontal nor vertical neighbours may cover the ring's outer edge.
+    expect(style.outlineOffset + parseFloat(style.outline)).toBeLessThanOrEqual(GAP);
+    expect(style.zIndex).toBeUndefined();
+    expect(node(false).props.style.outlineOffset).toBe(3);
+  }
+});

--- a/components/M3Node.tsx
+++ b/components/M3Node.tsx
@@ -1336,7 +1336,7 @@ export function M3Node({
   pressed?: boolean;
   dragging?: boolean;
   selected?: boolean;
-  /** the part sits in a connected run (non-free group, or a hidden run inside a free group) */
+  /** Connected parts need their selection ring to fit inside the run gap. */
   inRun?: boolean;
   interactive?: boolean;
   onPointerDown?: (e: React.PointerEvent) => void;
@@ -1379,19 +1379,14 @@ export function M3Node({
         display: measured ? "inline-flex" : "block",
         alignItems: "center",
         overflow: clips ? "hidden" : "visible",
-        /* the selection ring sticks out 5px (3px offset + 2px ring); in a run the next
-           sibling sits 3px away and would overpaint that edge — lift the selected part.
-           Runs never overlap, so the lift only beats the sibling that hides the ring.
-           Lone parts in free groups may overlap by design: keep their layer order. */
-        position: selected && inRun ? "relative" : undefined,
-        zIndex: selected && inRun ? 1 : undefined,
         cursor: !interactive ? "default" : dragging ? "grabbing" : "grab",
         userSelect: "none",
         touchAction: "none",
         boxSizing: "border-box",
         boxShadow: shadowOf(item),
         outline: selected ? `2px solid ${palette.primary}` : "2px solid transparent",
-        outlineOffset: 3,
+        /* Fit the 2px ring inside the 3px run gap, including adjacent multi-selection. */
+        outlineOffset: inRun ? 1 : 3,
         /* a part that changes width with its screen eases the way the screen does */
         transition: measured ? "outline-color 120ms" : `outline-color 120ms, width ${SETTLE_MS}ms cubic-bezier(0.2, 0, 0, 1)`,
         flex: "0 0 auto",

--- a/components/M3Node.tsx
+++ b/components/M3Node.tsx
@@ -1324,6 +1324,7 @@ export function M3Node({
   pressed,
   dragging,
   selected,
+  inRun = false,
   interactive = true,
   onPointerDown,
   tabScroll,
@@ -1335,6 +1336,8 @@ export function M3Node({
   pressed?: boolean;
   dragging?: boolean;
   selected?: boolean;
+  /** the part sits in a connected run (non-free group, or a hidden run inside a free group) */
+  inRun?: boolean;
   interactive?: boolean;
   onPointerDown?: (e: React.PointerEvent) => void;
   /** how far a scrollable tab row is scrolled in the preview; the canvas uses the resting position */
@@ -1376,10 +1379,12 @@ export function M3Node({
         display: measured ? "inline-flex" : "block",
         alignItems: "center",
         overflow: clips ? "hidden" : "visible",
-        /* the selection ring sticks out 5px (3px offset + 2px ring); in a connected run the next
-           sibling sits 3px below and would overpaint its bottom edge — lift selected parts instead */
-        position: selected ? "relative" : undefined,
-        zIndex: selected ? 1 : undefined,
+        /* the selection ring sticks out 5px (3px offset + 2px ring); in a run the next
+           sibling sits 3px away and would overpaint that edge — lift the selected part.
+           Runs never overlap, so the lift only beats the sibling that hides the ring.
+           Lone parts in free groups may overlap by design: keep their layer order. */
+        position: selected && inRun ? "relative" : undefined,
+        zIndex: selected && inRun ? 1 : undefined,
         cursor: !interactive ? "default" : dragging ? "grabbing" : "grab",
         userSelect: "none",
         touchAction: "none",

--- a/components/M3Node.tsx
+++ b/components/M3Node.tsx
@@ -1376,6 +1376,10 @@ export function M3Node({
         display: measured ? "inline-flex" : "block",
         alignItems: "center",
         overflow: clips ? "hidden" : "visible",
+        /* the selection ring sticks out 5px (3px offset + 2px ring); in a connected run the next
+           sibling sits 3px below and would overpaint its bottom edge — lift selected parts instead */
+        position: selected ? "relative" : undefined,
+        zIndex: selected ? 1 : undefined,
         cursor: !interactive ? "default" : dragging ? "grabbing" : "grab",
         userSelect: "none",
         touchAction: "none",


### PR DESCRIPTION
## Problem

A selected part draws a 2px outline 3px outside its box. In a connected run the next part sits only 3px away, so the outline overlaps that sibling and its opaque fill can cover the trailing edge. Giving every selected part the same raised z-index fixes a single selection, but adjacent selected parts still fall back to DOM order and can cover each other's outlines.

### Before (bottom edge missing) / After (all four edges render)

![Before: the selection ring's bottom edge is covered by the next list item](https://raw.githubusercontent.com/Cokedog320/m3e-canvas/assets/selection-ring/pr-414/selection-ring-before.png)

![After: the ring renders on all four sides](https://raw.githubusercontent.com/Cokedog320/m3e-canvas/assets/selection-ring/pr-414/selection-ring-after.png)

## Fix

For parts in connected runs, reduce the outline offset from 3px to 1px. The 2px outline then fits exactly within the existing 3px gap, so later siblings cannot cover it even when adjacent parts are selected together. Lone parts keep the original 3px offset, and no component is raised above its siblings.

## Validation

- `npm run typecheck` passes
- `npm test` — 665 tests pass
- Added a regression test that checks the run outline stays within the 3px gap and does not change z-order
- Addresses cubic's P2 report for adjacent multi-selection

## Why no issue

Skipped opening an issue because this remains a focused rendering fix: 3 files changed, 37 insertions and 1 deletion relative to `main`; 24 of the added lines are the regression test. It changes only the selection-ring offset for connected parts and preserves the existing spacing and layer order.
