### PR TITLE
Fix saved-language flash before hydration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/* Select only translated text, never hide the editor or its controls. */
+.m3e-locale-text > [data-text-lang] { display: none; }
+html[lang="ja"] .m3e-locale-text > [data-text-lang="ja"],
+html[lang="en"] .m3e-locale-text > [data-text-lang="en"],
+html[lang="zh"] .m3e-locale-text > [data-text-lang="zh"],
+html[lang="ko"] .m3e-locale-text > [data-text-lang="ko"] { display: inline; }
+
 html,
 body {
   height: 100%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
+import { LANGUAGE_BOOTSTRAP } from "@/lib/language-bootstrap";
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 
@@ -27,8 +28,9 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: LANGUAGE_BOOTSTRAP }} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -644,8 +644,11 @@ export default function Page() {
     try {
       const d = localStorage.getItem(DOC_KEY);
       if (d) {
-        hadDocRef.current = true;
-        applyDoc(JSON.parse(d) as Partial<Doc>, false);
+        const doc: unknown = JSON.parse(d);
+        if (doc && typeof doc === "object" && !Array.isArray(doc)) {
+          applyDoc(doc as Partial<Doc>, false);
+          hadDocRef.current = true;
+        }
         // frame mode is decided by the device (media-query effect), not restored
       }
       const before = d ? localStorage.getItem(BEFORE_KEY) : null;
@@ -4021,7 +4024,7 @@ export default function Page() {
                 <Segmented<"edit" | "prompt">
                   options={[
                     { key: "edit", icon: "tune", title: t("edit", lang), grow: false, wide: true },
-                    { key: "prompt", icon: "auto_awesome", label: t("prompt", lang), labelContent: <UIText id="prompt" />, title: t("prompt", lang), grow: true },
+                    { key: "prompt", icon: "auto_awesome", label: t("prompt", lang), localizedLabel: (language) => t("prompt", language), grow: true },
                   ]}
                   value={rightTab}
                   onChange={setRightTab}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -83,6 +83,7 @@ import { LayersPanel } from "@/components/Layers";
 import { FrameInspector, FrameSizePicker, Inspector } from "@/components/Inspector";
 import { Preview } from "@/components/Preview";
 import { Logo } from "@/components/Logo";
+import { UIText } from "@/components/LocaleText";
 import { initialLanguage } from "@/lib/initial-language";
 import { PartsPalette } from "@/components/PartsPalette";
 import { PromptPanel } from "@/components/PromptPanel";
@@ -3435,7 +3436,7 @@ export default function Page() {
                     flex: 1,
                   }}
                 >
-                  {t(LEFT_TABS.find((x) => x.key === leftTab)?.title ?? "parts", lang)}
+                  <UIText id={LEFT_TABS.find((x) => x.key === leftTab)?.title ?? "parts"} />
                 </span>
                 <IconBtn
                   icon="left_panel_close"
@@ -4020,7 +4021,7 @@ export default function Page() {
                 <Segmented<"edit" | "prompt">
                   options={[
                     { key: "edit", icon: "tune", title: t("edit", lang), grow: false, wide: true },
-                    { key: "prompt", icon: "auto_awesome", label: t("prompt", lang), title: t("prompt", lang), grow: true },
+                    { key: "prompt", icon: "auto_awesome", label: t("prompt", lang), labelContent: <UIText id="prompt" />, title: t("prompt", lang), grow: true },
                   ]}
                   value={rightTab}
                   onChange={setRightTab}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -83,6 +83,7 @@ import { LayersPanel } from "@/components/Layers";
 import { FrameInspector, FrameSizePicker, Inspector } from "@/components/Inspector";
 import { Preview } from "@/components/Preview";
 import { Logo } from "@/components/Logo";
+import { initialLanguage } from "@/lib/initial-language";
 import { PartsPalette } from "@/components/PartsPalette";
 import { PromptPanel } from "@/components/PromptPanel";
 import { GitHubLink, Mode, Toolbar } from "@/components/Toolbar";
@@ -102,7 +103,7 @@ import { MotionPanel, ShapePanel, TypePanel } from "@/components/ThemePanel";
 import { ThemeContext, ensureFontLoaded, ensureLangFontLoaded } from "@/lib/theme";
 import { BottomSheet, MobileActionBar, MobileInspector, MobileLang, MobileSettings } from "@/components/Mobile";
 import { ConfirmDialog, IconBtn, Segmented } from "@/components/ui";
-import { Lang, LangContext, SEED_TEXT, getLang, isLang, setGlobalLang, t, translateDefaultFrameName, translateDefaultText } from "@/lib/i18n";
+import { Lang, LangContext, SEED_TEXT, getLang, setGlobalLang, t, translateDefaultFrameName, translateDefaultText } from "@/lib/i18n";
 
 /** the screens while a model drafts: primary, tertiary and primary container, drifting */
 const DRAFT_GRADIENT = (p: Palette) => `linear-gradient(120deg, ${p.primaryContainer}, ${p.tertiaryContainer}, ${p.primary}, ${p.secondaryContainer}, ${p.primaryContainer})`;
@@ -349,6 +350,7 @@ export default function Page() {
   const patchTheme = (patch: Partial<Theme>) => setTheme((t) => ({ ...t, ...patch }));
   const [frame, setFrame] = useState<FrameMode>("phone");
   const [lang, setLang] = useState<Lang>("ja");
+  const [initialized, setInitialized] = useState(false);
   const changeLanguage = (next: Lang) => {
     setGlobalLang(next);
     initialLangRef.current = next;
@@ -634,6 +636,10 @@ export default function Page() {
   useEffect(() => {
     // React's development double-run would otherwise read back its own first save
     if (loadedRef.current) return;
+    const initialLang = initialLanguage(() => localStorage.getItem(UI_KEY), navigator.language ?? "");
+    setLang(initialLang);
+    setGlobalLang(initialLang);
+    initialLangRef.current = initialLang;
     try {
       const d = localStorage.getItem(DOC_KEY);
       if (d) {
@@ -648,7 +654,6 @@ export default function Page() {
         if (isProject(value)) setDraftBefore(value);
         else localStorage.removeItem(BEFORE_KEY);
       }
-      let initialLang: Lang = "ja";
       const u = localStorage.getItem(UI_KEY);
       if (u) {
         const ui = JSON.parse(u);
@@ -659,33 +664,26 @@ export default function Page() {
         if (ui.rightW) setRightW(ui.rightW);
         if (Array.isArray(ui.favorites)) setFavorites(ui.favorites);
         if (ui.mode) setMode(ui.mode);
-        if (isLang(ui.lang)) {
-          initialLang = ui.lang;
-          setLang(ui.lang);
-        }
       } else {
-        const nl = (navigator.language ?? "").toLowerCase();
-        initialLang = nl.startsWith("zh") ? "zh" : nl.startsWith("ko") ? "ko" : nl.startsWith("ja") ? "ja" : "en";
-        setLang(initialLang);
         queueMicrotask(() => fitRef.current());
       }
-      setGlobalLang(initialLang);
-      initialLangRef.current = initialLang;
-      if (!d) {
-        setGroups(seed(initialLang));
-        setFrames([{ ...SEED_FRAMES[0], name: t("home", initialLang) }]);
-      }
     } catch {}
+    if (!hadDocRef.current) {
+      setGroups(seed(initialLang));
+      setFrames([{ ...SEED_FRAMES[0], name: t("home", initialLang) }]);
+    }
     setAiSettings(loadAiSettings());
     loadedRef.current = true;
+    setInitialized(true);
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!initialized) return;
     document.documentElement.lang = lang;
     /* the editor's own text and the parts both pick up the language's Noto face */
     document.body.style.fontFamily = uiFontFamily(lang);
     ensureLangFontLoaded(lang, () => setWidths({}));
-  }, [lang]);
+  }, [initialized, lang]);
 
   useEffect(() => {
     /* an empty width map makes every measured part read its width again in the new face */
@@ -760,17 +758,17 @@ export default function Page() {
   }, []);
 
   useEffect(() => {
-    if (!loadedRef.current || editAccess !== "editable") return;
+    if (!initialized || editAccess !== "editable") return;
     try {
       localStorage.setItem(
         DOC_KEY,
         JSON.stringify({ groups, frames, paletteKey, frame, title, brief, promptEdit, platform: platform ?? undefined, customPalette: customPalette ?? undefined, dynamicColor, theme }),
       );
     } catch {}
-  }, [editAccess, groups, frames, paletteKey, frame, title, brief, promptEdit, platform, customPalette, dynamicColor, theme]);
+  }, [initialized, editAccess, groups, frames, paletteKey, frame, title, brief, promptEdit, platform, customPalette, dynamicColor, theme]);
 
   useEffect(() => {
-    if (!loadedRef.current) return;
+    if (!initialized) return;
     try {
       localStorage.setItem(
         UI_KEY,
@@ -787,6 +785,7 @@ export default function Page() {
       );
     } catch {}
   }, [
+    initialized,
     view,
     leftOpen,
     rightOpen,

--- a/components/LocaleText.test.tsx
+++ b/components/LocaleText.test.tsx
@@ -8,6 +8,7 @@ describe("pre-paint localized text", () => {
     const html = renderToStaticMarkup(<UIText id="search" />);
     for (const { key } of LANGS) {
       expect(html).toContain(`data-text-lang="${key}">${t("search", key)}</span>`);
+      expect(html.split(`data-text-lang="${key}"`)).toHaveLength(2);
     }
   });
 

--- a/components/LocaleText.test.tsx
+++ b/components/LocaleText.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { LANGS, t } from "../lib/i18n";
+import { LocaleText, UIText } from "./LocaleText";
+
+describe("pre-paint localized text", () => {
+  it("includes each translation once in stable markup", () => {
+    const html = renderToStaticMarkup(<UIText id="search" />);
+    for (const { key } of LANGS) {
+      expect(html).toContain(`data-text-lang="${key}">${t("search", key)}</span>`);
+    }
+  });
+
+  it("escapes translations as text instead of interpreting markup", () => {
+    const html = renderToStaticMarkup(<LocaleText text={() => "<script>test</script>"} />);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/components/LocaleText.tsx
+++ b/components/LocaleText.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { LANGS, type Lang, t, type UIKey } from "../lib/i18n";
+
+/** Identical server/client markup; the head bootstrap selects the visible language. */
+export function LocaleText({ text }: { text: (lang: Lang) => string }) {
+  return (
+    <span className="m3e-locale-text">
+      {LANGS.map(({ key }) => <span key={key} data-text-lang={key}>{text(key)}</span>)}
+    </span>
+  );
+}
+
+export function UIText({ id }: { id: UIKey }) {
+  return <LocaleText text={(lang) => t(id, lang)} />;
+}

--- a/components/PartsPalette.tsx
+++ b/components/PartsPalette.tsx
@@ -44,7 +44,7 @@ export function PartsPalette({
         key={k}
         icon={s.paletteIcon}
         label={labelOf(k)}
-        labelContent={<LocaleText text={(language) => language === "en" ? s.label : KIND_TEXT[language][k]?.noun ?? s.label} />}
+        localizedLabel={(language) => language === "en" ? s.label : KIND_TEXT[language][k]?.noun ?? s.label}
         p={p}
         onPointerDown={(e) => onPartPointerDown(e, k)}
         starred={favorites.includes(k)}

--- a/components/PartsPalette.tsx
+++ b/components/PartsPalette.tsx
@@ -3,8 +3,9 @@
 import { useMemo, useState } from "react";
 import { CATEGORIES, KIND_ORDER, KIND_SPEC, Category, Kind, Palette } from "@/lib/tokens";
 import { Icon } from "./M3Node";
-import { KIND_TEXT, t, useLang } from "@/lib/i18n";
+import { KIND_TEXT, useLang } from "@/lib/i18n";
 import { Field, Section, Tile } from "./ui";
+import { LocaleText, UIText } from "./LocaleText";
 
 const CATEGORY_TEXT = {
   ja: { actions: "操作", navigation: "ナビゲーション", containment: "コンテナ", inputs: "入力", content: "コンテンツ", progress: "進捗" },
@@ -43,6 +44,7 @@ export function PartsPalette({
         key={k}
         icon={s.paletteIcon}
         label={labelOf(k)}
+        labelContent={<LocaleText text={(language) => language === "en" ? s.label : KIND_TEXT[language][k]?.noun ?? s.label} />}
         p={p}
         onPointerDown={(e) => onPartPointerDown(e, k)}
         starred={favorites.includes(k)}
@@ -60,12 +62,12 @@ export function PartsPalette({
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", position: "relative" }}>
       <div style={{ padding: "12px 12px 8px" }}>
-        <Field value={q} onChange={setQ} placeholder={t("search", lang)} p={p} icon="search" height={40} />
+        <Field value={q} onChange={setQ} placeholderKey="search" p={p} icon="search" height={40} />
       </div>
 
       <div className="no-scrollbar" style={{ flex: 1, overflowY: "auto", overflowX: "hidden", padding: "0 8px" }}>
         {!q && favorites.length > 0 && (
-          <Section id="fav" icon="star" title={t("favorites", lang)} p={p}>
+          <Section id="fav" icon="star" title={<UIText id="favorites" />} p={p}>
             <div style={grid}>{favorites.filter((k) => KIND_SPEC[k]).map(tile)}</div>
           </Section>
         )}
@@ -80,7 +82,7 @@ export function PartsPalette({
           </div>
         ) : (
           CATEGORIES.map((c) => (
-            <Section key={c.key} id={`cat:${c.key}`} icon={c.icon} title={lang === "en" ? c.label : CATEGORY_TEXT[lang][c.key]} p={p}>
+            <Section key={c.key} id={`cat:${c.key}`} icon={c.icon} title={<LocaleText text={(language) => language === "en" ? c.label : CATEGORY_TEXT[language][c.key]} />} p={p}>
               <div style={grid}>{KIND_ORDER.filter((k) => KIND_SPEC[k].category === c.key).map(tile)}</div>
             </Section>
           ))

--- a/components/ShareMenu.tsx
+++ b/components/ShareMenu.tsx
@@ -6,6 +6,7 @@ import { Doc, Palette } from "@/lib/tokens";
 import { shareLink } from "@/lib/share";
 import { Icon } from "./M3Node";
 import { t, useLang } from "@/lib/i18n";
+import { UIText } from "./LocaleText";
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 
@@ -39,7 +40,7 @@ export function ShareButton({ p, onClick, busy }: { p: Palette; onClick: () => v
       }}
     >
       {busy && <Icon name="hourglass_top" size={18} />}
-      {busy ? t("askAiGenerating", lang) : t("askAi", lang)}
+      <UIText id={busy ? "askAiGenerating" : "askAi"} />
       {!busy && <Beta p={p} />}
     </button>
   );

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import { ShareButton } from "./ShareMenu";
 import { Icon } from "./M3Node";
 import { Popover } from "./Menus";
 import { t, useLang } from "@/lib/i18n";
+import { UIText } from "./LocaleText";
 
 export type Mode = "select" | "hand";
 
@@ -179,7 +180,7 @@ export function Toolbar({
             }}
           >
             <Icon name="auto_awesome" size={22} />
-            {t("prompt", lang)}
+            <UIText id="prompt" />
           </button>
         </Pill>
       </div>

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { COLOR_TOKENS, CardLayout, ColorToken, PLACES, Palette, Place, R_INNER, TEXT_TOKENS, TextToken, clamp } from "@/lib/tokens";
 import { AnimatePresence, motion } from "motion/react";
-import { COLOR_TOKEN_TEXT, TEXT_TOKEN_TEXT, t, useLang } from "@/lib/i18n";
+import { COLOR_TOKEN_TEXT, TEXT_TOKEN_TEXT, LANGS, t, useLang, type UIKey } from "@/lib/i18n";
 import { Icon } from "./M3Node";
 import { onColorFor } from "@/lib/color";
 
@@ -59,7 +59,7 @@ export function IconBtn({
   );
 }
 
-export type SegOption<K extends string> = { key: K; icon?: string; label?: string; title?: string; /** small marker: this option carries something */ dot?: boolean; /** this option alone takes the spare width */ grow?: boolean; /** an icon-only option that should not shrink to a square */ wide?: boolean };
+export type SegOption<K extends string> = { key: K; icon?: string; label?: string; labelContent?: React.ReactNode; title?: string; /** small marker: this option carries something */ dot?: boolean; /** this option alone takes the spare width */ grow?: boolean; /** an icon-only option that should not shrink to a square */ wide?: boolean };
 
 /** Connected-button group with the same fused corners as the canvas. */
 export function Segmented<K extends string>({
@@ -115,7 +115,7 @@ export function Segmented<K extends string>({
             }}
           >
             {o.icon && <Icon name={o.icon} size={Math.round(height * 0.5)} fill={on} />}
-            {o.label && <span>{o.label}</span>}
+            {o.label && <span>{o.labelContent ?? o.label}</span>}
             {o.dot && (
               <span
                 aria-hidden
@@ -141,6 +141,7 @@ export function Field({
   value,
   onChange,
   placeholder,
+  placeholderKey,
   p,
   icon,
   multiline,
@@ -151,6 +152,8 @@ export function Field({
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
+  /** Localize the static search placeholder before React hydrates. */
+  placeholderKey?: UIKey;
   p: Palette;
   icon?: string;
   multiline?: boolean;
@@ -169,6 +172,8 @@ export function Field({
     el.style.height = "auto";
     el.style.height = `${el.scrollHeight}px`;
   }, [value, grow]);
+  const localizedPlaceholder = placeholderKey ? t(placeholderKey, lang) : placeholder;
+  const placeholderLabels = placeholderKey ? JSON.stringify(Object.fromEntries(LANGS.map(({ key }) => [key, t(placeholderKey, key)]))) : undefined;
   const base: React.CSSProperties = {
     width: "100%",
     padding: multiline ? `12px ${filled ? 40 : 14}px 12px ${icon ? 42 : 14}px` : `0 ${filled ? 40 : 14}px 0 ${icon ? 42 : 14}px`,
@@ -202,18 +207,23 @@ export function Field({
       {multiline ? (
         <textarea
           ref={areaRef}
+          data-ui-placeholder={placeholderLabels}
+          // The head bootstrap translates this attribute before hydration.
+          suppressHydrationWarning={!!placeholderKey}
           value={value}
           rows={rows}
           onChange={(e) => onChange(grow ? e.target.value.replace(/[\r\n]+/g, " ") : e.target.value)}
           onKeyDown={grow ? (e) => { if (e.key === "Enter") e.preventDefault(); } : undefined}
-          placeholder={placeholder}
+          placeholder={localizedPlaceholder}
           style={grow ? { ...base, overflow: "hidden" } : base}
         />
       ) : (
         <input
+          data-ui-placeholder={placeholderLabels}
+          suppressHydrationWarning={!!placeholderKey}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
+          placeholder={localizedPlaceholder}
           style={{ ...base, height }}
         />
       )}
@@ -615,7 +625,7 @@ export function Section({
 }: {
   id: string;
   icon: string;
-  title: string;
+  title: React.ReactNode;
   p: Palette;
   children: React.ReactNode;
   right?: React.ReactNode;
@@ -676,6 +686,7 @@ export function Section({
 export function Tile({
   icon,
   label,
+  labelContent,
   p,
   onPointerDown,
   onClick,
@@ -686,6 +697,7 @@ export function Tile({
 }: {
   icon: string;
   label: string;
+  labelContent?: React.ReactNode;
   p: Palette;
   onPointerDown?: (e: React.PointerEvent) => void;
   onClick?: () => void;
@@ -733,7 +745,7 @@ export function Tile({
           maxWidth: "100%",
         }}
       >
-        {label}
+        {labelContent ?? label}
       </span>
       {onStar && (
         <button

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { COLOR_TOKENS, CardLayout, ColorToken, PLACES, Palette, Place, R_INNER, TEXT_TOKENS, TextToken, clamp } from "@/lib/tokens";
 import { AnimatePresence, motion } from "motion/react";
-import { COLOR_TOKEN_TEXT, TEXT_TOKEN_TEXT, LANGS, t, useLang, type UIKey } from "@/lib/i18n";
+import { COLOR_TOKEN_TEXT, TEXT_TOKEN_TEXT, LANGS, t, useLang, type Lang, type UIKey } from "@/lib/i18n";
+import { LocaleText } from "./LocaleText";
 import { Icon } from "./M3Node";
 import { onColorFor } from "@/lib/color";
 
@@ -59,7 +60,7 @@ export function IconBtn({
   );
 }
 
-export type SegOption<K extends string> = { key: K; icon?: string; label?: string; labelContent?: React.ReactNode; title?: string; /** small marker: this option carries something */ dot?: boolean; /** this option alone takes the spare width */ grow?: boolean; /** an icon-only option that should not shrink to a square */ wide?: boolean };
+export type SegOption<K extends string> = { key: K; icon?: string; label?: string; localizedLabel?: (lang: Lang) => string; title?: string; /** small marker: this option carries something */ dot?: boolean; /** this option alone takes the spare width */ grow?: boolean; /** an icon-only option that should not shrink to a square */ wide?: boolean };
 
 /** Connected-button group with the same fused corners as the canvas. */
 export function Segmented<K extends string>({
@@ -84,12 +85,16 @@ export function Segmented<K extends string>({
         const first = i === 0;
         const last = i === options.length - 1;
         const outer = height / 2;
+        const labels = o.localizedLabel && JSON.stringify(Object.fromEntries(LANGS.map(({ key }) => [key, o.localizedLabel!(key)])));
         return (
           <button
             key={o.key}
             onClick={() => onChange(o.key)}
             title={o.title ?? o.label}
             aria-label={o.title ?? o.label}
+            data-ui-title={labels}
+            data-ui-aria-label={labels}
+            suppressHydrationWarning={!!labels}
             className="m3-press"
             style={{
               flex: (o.grow ?? grow) ? 1 : "0 0 auto",
@@ -115,7 +120,7 @@ export function Segmented<K extends string>({
             }}
           >
             {o.icon && <Icon name={o.icon} size={Math.round(height * 0.5)} fill={on} />}
-            {o.label && <span>{o.labelContent ?? o.label}</span>}
+            {o.label && <span>{o.localizedLabel ? <LocaleText text={o.localizedLabel} /> : o.label}</span>}
             {o.dot && (
               <span
                 aria-hidden
@@ -686,7 +691,7 @@ export function Section({
 export function Tile({
   icon,
   label,
-  labelContent,
+  localizedLabel,
   p,
   onPointerDown,
   onClick,
@@ -697,7 +702,7 @@ export function Tile({
 }: {
   icon: string;
   label: string;
-  labelContent?: React.ReactNode;
+  localizedLabel?: (lang: Lang) => string;
   p: Palette;
   onPointerDown?: (e: React.PointerEvent) => void;
   onClick?: () => void;
@@ -713,6 +718,8 @@ export function Tile({
       onPointerDown={onPointerDown}
       onClick={onClick}
       title={label}
+      data-ui-title={localizedLabel && JSON.stringify(Object.fromEntries(LANGS.map(({ key }) => [key, localizedLabel(key)])))}
+      suppressHydrationWarning={!!localizedLabel}
       style={{
         position: "relative",
         display: "flex",
@@ -745,7 +752,7 @@ export function Tile({
           maxWidth: "100%",
         }}
       >
-        {labelContent ?? label}
+        {localizedLabel ? <LocaleText text={localizedLabel} /> : label}
       </span>
       {onStar && (
         <button

--- a/lib/initial-language.test.ts
+++ b/lib/initial-language.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { initialLanguage } from "./initial-language";
+import { LANGS } from "./i18n";
+
+describe("initialLanguage", () => {
+  it("prefers every supported saved language over the browser", () => {
+    for (const { key } of LANGS) {
+      expect(initialLanguage(() => JSON.stringify({ lang: key }), "fr-FR")).toBe(key);
+    }
+  });
+
+  it.each([["zh-CN", "zh"], ["ZH-TW", "zh"], ["ko-KR", "ko"], ["ja-JP", "ja"], ["en-US", "en"], ["fr-FR", "en"], ["", "en"]])(
+    "resolves browser %s to %s", (browser, expected) => {
+      expect(initialLanguage(() => null, browser)).toBe(expected);
+    },
+  );
+
+  it.each(["{", "null", "{}", "[]", "42", '{"lang":"fr"}', '{"lang":null}'])(
+    "falls back for invalid settings %s", (stored) => {
+      expect(initialLanguage(() => stored, "zh-CN")).toBe("zh");
+    },
+  );
+
+  it("falls back when access to storage throws", () => {
+    expect(initialLanguage(() => { throw new Error("Blocked"); }, "ko-KR")).toBe("ko");
+  });
+});

--- a/lib/initial-language.ts
+++ b/lib/initial-language.ts
@@ -1,0 +1,11 @@
+import { isLang, type Lang } from "./i18n";
+
+/** Storage may be unavailable or malformed; neither should prevent startup. */
+export function initialLanguage(readUi: () => string | null, browserLanguage: string): Lang {
+  try {
+    const ui = JSON.parse(readUi() ?? "null");
+    if (isLang(ui?.lang)) return ui.lang;
+  } catch {}
+  const language = browserLanguage.toLowerCase();
+  return language.startsWith("zh") ? "zh" : language.startsWith("ko") ? "ko" : language.startsWith("ja") ? "ja" : "en";
+}

--- a/lib/language-bootstrap.test.ts
+++ b/lib/language-bootstrap.test.ts
@@ -43,17 +43,17 @@ describe("pre-paint language bootstrap", () => {
     expect(document.documentElement.lang).toBe("zh");
   });
 
-  it("localizes a parsed field and stops observing after HTML parsing", () => {
+  it.each(["placeholder", "title", "aria-label"])("localizes a parsed %s and stops observing after HTML parsing", (attribute) => {
     const result = bootstrap("zh-CN", () => null);
     const setAttribute = vi.fn();
     result.mutate([{
       nodeType: 1,
-      hasAttribute: () => true,
+      hasAttribute: (name: string) => name === `data-ui-${attribute}`,
       getAttribute: () => JSON.stringify({ ja: "検索", en: "Search", zh: "搜索", ko: "검색" }),
       setAttribute,
       querySelectorAll: () => [],
     }]);
-    expect(setAttribute).toHaveBeenCalledWith("placeholder", "搜索");
+    expect(setAttribute).toHaveBeenCalledExactlyOnceWith(attribute, "搜索");
     expect(result.observe).toHaveBeenCalledWith(result.document.documentElement, { childList: true, subtree: true });
     result.ready();
     expect(result.disconnect).toHaveBeenCalledOnce();

--- a/lib/language-bootstrap.test.ts
+++ b/lib/language-bootstrap.test.ts
@@ -1,0 +1,61 @@
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+import { LANGS } from "./i18n";
+import { initialLanguage } from "./initial-language";
+import { LANGUAGE_BOOTSTRAP } from "./language-bootstrap";
+
+function bootstrap(language: string, readUi: () => string | null) {
+  const observe = vi.fn();
+  const disconnect = vi.fn();
+  let mutation: (records: { addedNodes: unknown[] }[]) => void = () => {};
+  let ready = () => {};
+  const document = {
+    documentElement: { lang: "ja" },
+    addEventListener: vi.fn((_event: string, callback: () => void) => { ready = callback; }),
+  };
+  class Observer {
+    constructor(callback: typeof mutation) { mutation = callback; }
+    observe = observe;
+    disconnect = disconnect;
+  }
+  runInNewContext(LANGUAGE_BOOTSTRAP, {
+    document,
+    navigator: { language },
+    get localStorage() { return { getItem: readUi }; },
+    MutationObserver: Observer,
+  });
+  return { document, observe, disconnect, mutate: (nodes: unknown[]) => mutation([{ addedNodes: nodes }]), ready: () => ready() };
+}
+
+describe("pre-paint language bootstrap", () => {
+  const settings = [null, "{", "null", "{}", "[]", "42", '{"lang":"fr"}', ...LANGS.map(({ key }) => JSON.stringify({ lang: key }))];
+  it.each(["ja-JP", "en-US", "zh-CN", "ZH-TW", "ko-KR", "fr-FR", ""])(
+    "agrees with React initialization for browser %s", (language) => {
+      for (const stored of settings) {
+        const { document } = bootstrap(language, () => stored);
+        expect(document.documentElement.lang).toBe(initialLanguage(() => stored, language));
+      }
+    },
+  );
+
+  it("uses the browser language when reading localStorage throws", () => {
+    const { document } = bootstrap("zh-CN", () => { throw new Error("Blocked"); });
+    expect(document.documentElement.lang).toBe("zh");
+  });
+
+  it("localizes a parsed field and stops observing after HTML parsing", () => {
+    const result = bootstrap("zh-CN", () => null);
+    const setAttribute = vi.fn();
+    result.mutate([{
+      nodeType: 1,
+      hasAttribute: () => true,
+      getAttribute: () => JSON.stringify({ ja: "検索", en: "Search", zh: "搜索", ko: "검색" }),
+      setAttribute,
+      querySelectorAll: () => [],
+    }]);
+    expect(setAttribute).toHaveBeenCalledWith("placeholder", "搜索");
+    expect(result.observe).toHaveBeenCalledWith(result.document.documentElement, { childList: true, subtree: true });
+    result.ready();
+    expect(result.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/lib/language-bootstrap.ts
+++ b/lib/language-bootstrap.ts
@@ -9,15 +9,19 @@ export const LANGUAGE_BOOTSTRAP = `(function(){
   document.documentElement.lang=lang;
   function localize(node){
     if(node.nodeType!==1)return;
-    if(node.hasAttribute('data-ui-placeholder')){
-      var labels=JSON.parse(node.getAttribute('data-ui-placeholder'));
-      node.setAttribute('placeholder',labels[lang]||'');
+    var attributes=['placeholder','title','aria-label'];
+    for(var a=0;a<attributes.length;a++){
+      var attribute=attributes[a];
+      if(node.hasAttribute('data-ui-'+attribute)){
+        var labels=JSON.parse(node.getAttribute('data-ui-'+attribute));
+        node.setAttribute(attribute,labels[lang]||'');
+      }
     }
-    var fields=node.querySelectorAll('[data-ui-placeholder]');
+    var fields=node.querySelectorAll('[data-ui-placeholder],[data-ui-title],[data-ui-aria-label]');
     for(var i=0;i<fields.length;i++)localize(fields[i]);
   }
-  // Attribute markers are available as soon as a complete input tag is parsed.
-  // Observe only additions, so our placeholder updates cannot trigger a loop.
+  // Attribute markers are available as soon as a complete element tag is parsed.
+  // Observe only additions, so our attribute updates cannot trigger a loop.
   var observer=new MutationObserver(function(records){
     for(var i=0;i<records.length;i++){
       for(var j=0;j<records[i].addedNodes.length;j++)localize(records[i].addedNodes[j]);

--- a/lib/language-bootstrap.ts
+++ b/lib/language-bootstrap.ts
@@ -1,0 +1,28 @@
+/** Runs in the head, before any editor text can be painted. */
+export const LANGUAGE_BOOTSTRAP = `(function(){
+  var language=(navigator.language||'').toLowerCase();
+  var lang=language.indexOf('zh')===0?'zh':language.indexOf('ko')===0?'ko':language.indexOf('ja')===0?'ja':'en';
+  try {
+    var ui=JSON.parse(localStorage.getItem('m3e:ui')||'null');
+    if(ui&&['ja','en','zh','ko'].indexOf(ui.lang)!==-1)lang=ui.lang;
+  } catch(e) {}
+  document.documentElement.lang=lang;
+  function localize(node){
+    if(node.nodeType!==1)return;
+    if(node.hasAttribute('data-ui-placeholder')){
+      var labels=JSON.parse(node.getAttribute('data-ui-placeholder'));
+      node.setAttribute('placeholder',labels[lang]||'');
+    }
+    var fields=node.querySelectorAll('[data-ui-placeholder]');
+    for(var i=0;i<fields.length;i++)localize(fields[i]);
+  }
+  // Attribute markers are available as soon as a complete input tag is parsed.
+  // Observe only additions, so our placeholder updates cannot trigger a loop.
+  var observer=new MutationObserver(function(records){
+    for(var i=0;i<records.length;i++){
+      for(var j=0;j<records[i].addedNodes.length;j++)localize(records[i].addedNodes[j]);
+    }
+  });
+  observer.observe(document.documentElement,{childList:true,subtree:true});
+  document.addEventListener('DOMContentLoaded',function(){observer.disconnect();},{once:true});
+})();`;


### PR DESCRIPTION
## What and why

The static export initially renders Japanese editor text, then restores the saved language after hydration. Reloading with another language selected therefore briefly shows the wrong language.

This PR fixes the visible editor text and search placeholder without adding a splash screen, hiding the editor, changing routes, or adding dependencies.

- Resolve the saved language independently of document recovery, with browser-language fallback for missing/invalid settings or unavailable storage. Avoid persisting the initial defaults before restoration finishes.
- Read the language in the document head before paint. Render stable localized text markup and select the matching translation through `html.lang`, so hydration does not need to replace the text structure.
- Localize explicitly marked placeholders as their elements are parsed. The temporary observer disconnects when HTML parsing finishes.

The work is split into two commits: language restoration and pre-hydration rendering. Existing translations and canvas-fit behavior are preserved.

## How I checked it

- [x] `npm run typecheck` passes
- [x] `npm test` passes: 691 tests across 22 files
- [x] `npm run build` passes (static export)
- [x] New or changed UI strings and prompt text exist in Japanese, English, Chinese and Korean (existing translations reused)
- [x] Tried it in the editor and at a phone viewport

Browser checks against the production export held back the Next.js JavaScript and checked that the editor remained visible with the selected language and search placeholder before hydration. Releasing the scripts produced no hydration/page errors or intervening wrong-language frames. Cases included all four languages, malformed/missing settings, blocked storage, a malformed document, and a phone viewport. Also checked switching English to Chinese through the language menu, searching, and reloading to confirm persistence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the saved-language flash on reload: the static export first painted Japanese editor text until hydration restored the user's language. The first paint now shows the saved language without hiding the editor, changing routes, or adding dependencies.

- Adds a head bootstrap script that reads the saved language and sets `html.lang` before any editor text paints.
- New `LocaleText` markup renders every translation in the DOM, and CSS shows only the one matching `html.lang`, so hydration leaves the text structure unchanged.
- `initialLanguage` resolves the saved language independently of document recovery, falling back to the browser language for missing, invalid, or unreadable settings.
- Placeholder, title, and aria-label attributes are localized as elements parse via `data-ui-*` markers; the observer disconnects at `DOMContentLoaded`.
- The editor avoids persisting its initial defaults until restoration finishes, and recovery now skips corrupted saved documents instead of applying them.

<sup>Written for commit 30cc205e35dc846182b17c619eb868ef4dbc4537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

