### PR TITLE
Stop a running design draft

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -440,6 +440,8 @@ export default function Page() {
   const projectFileRef = useRef<HTMLInputElement>(null);
   const aiNoteTimer = useRef<number | null>(null);
   const aiAbortRef = useRef<AbortController | null>(null);
+  /* the draft has its own controller: Stop ends the draft and leaves the other AI actions alone */
+  const draftAbortRef = useRef<AbortController | null>(null);
 
   const p = paletteOf(paletteKey, customPalette, theme);
   /* corner helpers read the shape scale outside React; keep it current before anything renders */
@@ -2125,6 +2127,8 @@ export default function Page() {
   /** Opening a project file replaces the canvas with the same restore path the saved
    *  document goes through, then starts the editor fresh on it. */
   const importDoc = (next: Doc) => {
+    /* a design that replaces what is on the canvas ends any draft still in flight */
+    cancelDraft();
     hadDocRef.current = true;
     /* the whole document being replaced stays one undo away */
     snapshot(true);
@@ -2200,21 +2204,40 @@ export default function Page() {
 
   const startDraft = async (idea: string) => {
     setShareOpen(false);
+    /* a second Generate replaces the first run instead of running beside it */
+    draftAbortRef.current?.abort();
+    const ac = new AbortController();
+    draftAbortRef.current = ac;
     setDraftBusy(true);
     try {
       if (guideRef.current === null) {
-        const res = await fetch(`${BASE_PATH}/agent.md`);
+        const res = await fetch(`${BASE_PATH}/agent.md`, { signal: ac.signal });
         if (!res.ok) throw new Error("guide");
         guideRef.current = await res.text();
       }
-      const next = await draftDesign(aiSettings, guideRef.current, idea, lang);
+      if (ac.signal.aborted) return;
+      const next = await draftDesign(aiSettings, guideRef.current, idea, lang, ac.signal);
+      /* a reply that lands after Stop never takes the canvas */
+      if (ac.signal.aborted) return;
       arrive(next);
     } catch (e) {
+      /* an aborted draft ends quietly: the author asked for it */
+      if (ac.signal.aborted) return;
       const m = e instanceof Error ? e.message : "";
       showToast(m === "json" ? t("aiErrorJson", lang) : m === "refusal" ? t("aiErrorRefusal", lang) : m === "long" ? t("aiErrorLong", lang) : t("aiError", lang), 3200, "error");
     } finally {
-      setDraftBusy(false);
+      if (draftAbortRef.current === ac) {
+        draftAbortRef.current = null;
+        setDraftBusy(false);
+      }
     }
+  };
+
+  /** Stop while a draft runs: the request is dropped and the design on the canvas stays as it was */
+  const cancelDraft = () => {
+    draftAbortRef.current?.abort();
+    draftAbortRef.current = null;
+    setDraftBusy(false);
   };
   /** true after a kept draft until the author undoes something, so the header's undo also sits by the opener */
   const [quickUndo, setQuickUndo] = useState(false);
@@ -2502,6 +2525,7 @@ export default function Page() {
   useEffect(
     () => () => {
       aiAbortRef.current?.abort();
+      draftAbortRef.current?.abort();
       if (aiNoteTimer.current) window.clearTimeout(aiNoteTimer.current);
       if (toastTimer.current) window.clearTimeout(toastTimer.current);
     },
@@ -3953,6 +3977,39 @@ export default function Page() {
               </BottomSheet>
             )}
           </AnimatePresence>
+
+          {/* Stop stays in reach while a model drafts, instead of leaving the author to reload */}
+          {draftBusy && (
+            <button
+              onClick={cancelDraft}
+              title={t("cancel", lang)}
+              className="m3-press"
+              style={{
+                position: "absolute",
+                left: "50%",
+                bottom: 152,
+                transform: "translateX(-50%)",
+                height: 40,
+                padding: "0 20px",
+                borderRadius: 20,
+                border: "none",
+                background: p.surfaceContainerHighest,
+                color: p.onSurface,
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: "pointer",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 8,
+                zIndex: 95,
+              }}
+            >
+              <span style={{ display: "inline-flex" }}>
+                <Icon name="stop" size={18} />
+              </span>
+              {t("cancel", lang)}
+            </button>
+          )}
 
           {toast && (
             <div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2110,6 +2110,8 @@ export default function Page() {
 
   const clearAll = () => {
     setConfirmClear(false);
+    /* an empty canvas is still a canvas: a draft that lands after a clear must not refill it */
+    cancelDraft();
     if (groupsRef.current.length === 0 && framesRef.current.length === 0)
       return;
     setDraftBefore(null);

--- a/lib/ai.test.ts
+++ b/lib/ai.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { complete, hasKey, isSecureUrl, type AiSettings, type Provider } from "./ai";
+import { complete, draftDesign, hasKey, isSecureUrl, type AiSettings, type Provider } from "./ai";
 
 const settings = (over: Partial<AiSettings> = {}): AiSettings =>
   ({ provider: "openai", baseUrl: "https://api.example.test", model: "test-model", key: "test-key", ...over });
@@ -132,5 +132,22 @@ describe("hasKey and isSecureUrl", () => {
     expect(isSecureUrl("http://127.0.0.1:8080/v1")).toBe(true);
     expect(isSecureUrl("http://[::1]:8080/v1")).toBe(true);
     expect(isSecureUrl("http://api.example.test/v1")).toBe(false);
+  });
+});
+
+describe("draftDesign cancellation", () => {
+  it("hands the caller's signal to the request and rejects on abort instead of answering", async () => {
+    const ac = new AbortController();
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const run = draftDesign(settings(), "guide text", "a notes app", "en", ac.signal);
+    ac.abort();
+    await expect(run).rejects.toThrow(/abort/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(ac.signal);
   });
 });


### PR DESCRIPTION
Fixes #417.

A draft now keeps its own AbortController, so a run that hangs or was started by mistake can be stopped without reloading the page. While the model is writing, a Stop button sits in reach by the loading indicator; pressing it drops the request and leaves the design on the canvas as it was.

- the signal reaches the agent.md fetch and `draftDesign`, so a hanging run ends immediately;
- an aborted run ends without an error toast â€” the author asked for it;
- a reply that lands after Stop never takes the canvas, and a new Generate replaces a still-running one instead of racing it;
- a design arriving from a link or an open ends any draft still in flight;
- the busy state is owned by the run that started last, so a replaced run cannot clear it.

Verification in `lib/ai.test.ts`: `draftDesign` forwards the abort signal and makes no second call after an abort.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Stop button to a running design draft so a hung or mistaken run can be cancelled without reloading the page; the design on the canvas stays as it was.

- The draft owns its own AbortController, and its signal reaches the `agent.md` fetch and `draftDesign`.
- An aborted run ends quietly with no error toast.
- A reply that lands after Stop never takes the canvas, and a new Generate replaces a still-running one instead of racing it.
- Opening a design from a link, an open, or clearing the canvas ends any draft still in flight.
- The busy state is cleared only by the run that started last, so a replaced run cannot clear it.
- Adds a test that `draftDesign` forwards the abort signal and makes no second call after an abort.
- Fixes #417.

<sup>Written for commit cf9a8c20d0334fe69825783f7581e5d53bcc28c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

