### PR TITLE
Ask once more when a complete reply is not valid JSON

### DIFF
--- a/lib/ai.test.ts
+++ b/lib/ai.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { complete, hasKey, isSecureUrl, type AiSettings, type Provider } from "./ai";
+import { complete, draftDesign, hasKey, isSecureUrl, type AiSettings, type Provider } from "./ai";
 
 const settings = (over: Partial<AiSettings> = {}): AiSettings =>
   ({ provider: "openai", baseUrl: "https://api.example.test", model: "test-model", key: "test-key", ...over });
@@ -132,5 +132,51 @@ describe("hasKey and isSecureUrl", () => {
     expect(isSecureUrl("http://127.0.0.1:8080/v1")).toBe(true);
     expect(isSecureUrl("http://[::1]:8080/v1")).toBe(true);
     expect(isSecureUrl("http://api.example.test/v1")).toBe(false);
+  });
+});
+
+describe("one retry for a reply that is not valid JSON", () => {
+  const project = { groups: [], frames: [{ id: "frame", name: "Home", x: 0, y: 0 }] };
+  const reply = (content: string) => jsonResponse({ choices: [{ finish_reason: "stop", message: { content } }] });
+  const trailingComma = `{"groups": [], "frames": [{"id": "frame", "name": "Home", "x": 0, "y": 0},]}`;
+
+  it("asks once more with the reminder and answers", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(reply(trailingComma))
+      .mockResolvedValueOnce(reply(JSON.stringify(project)));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(draftDesign(settings(), "guide text", "a notes app", "en")).resolves.toMatchObject({ frames: [{ id: "frame" }] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const second = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(second.messages[1].content).toContain("Your previous reply was not valid JSON");
+  });
+
+  it("fails as before when the second reply is not valid JSON either", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(reply(trailingComma)));
+    vi.stubGlobal("fetch", fetchMock);
+    /* the second failure surfaces exactly as a single malformed reply does today */
+    await expect(draftDesign(settings(), "guide text", "a notes app", "en")).rejects.toBeInstanceOf(SyntaxError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a reply the provider cut off", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "length", message: { content: "partial" } }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(draftDesign(settings(), "guide text", "a notes app", "en")).rejects.toThrow("long");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends no second request after an abort", async () => {
+    const ac = new AbortController();
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const run = draftDesign(settings(), "guide text", "a notes app", "en", ac.signal);
+    ac.abort();
+    await expect(run).rejects.toThrow(/abort/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/ai.test.ts
+++ b/lib/ai.test.ts
@@ -140,6 +140,13 @@ describe("one retry for a reply that is not valid JSON", () => {
   const reply = (content: string) => jsonResponse({ choices: [{ finish_reason: "stop", message: { content } }] });
   const trailingComma = `{"groups": [], "frames": [{"id": "frame", "name": "Home", "x": 0, "y": 0},]}`;
 
+  it("uses a reply that parses with a single request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(reply(JSON.stringify(project)));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(draftDesign(settings(), "guide text", "a notes app", "en")).resolves.toMatchObject({ frames: [{ id: "frame" }] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("asks once more with the reminder and answers", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(reply(trailingComma))

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -139,6 +139,22 @@ function parseJsonObject(text: string): Record<string, unknown> {
   return v as Record<string, unknown>;
 }
 
+const JSON_REMINDER = "Your previous reply was not valid JSON. Reply with the JSON object only: no prose, no code fence.";
+
+/** The model is asked for one JSON object. A complete reply that still does not parse — a
+ *  trailing comma, a comment, a smart quote — gets one more try with the reminder above; a
+ *  reply that was cut off by the output budget is not retried, because that belongs to the
+ *  prompt and the request, not to a second sample, and an aborted run stays ended. */
+async function completeObject(s: AiSettings, system: string, user: string, signal?: AbortSignal, maxTokens = 4096): Promise<Record<string, unknown>> {
+  const first = await complete(s, system, user, signal, maxTokens);
+  try {
+    return parseJsonObject(first);
+  } catch (e) {
+    if (signal?.aborted) throw e;
+    return parseJsonObject(await complete(s, system, `${user}\n\n${JSON_REMINDER}`, signal, maxTokens));
+  }
+}
+
 /* ---------- actions ---------- */
 
 const LANG_NAME: Record<Lang, string> = { ja: "Japanese", en: "English", zh: "Simplified Chinese", ko: "Korean" };
@@ -199,7 +215,7 @@ export async function proposeBehavior(s: AiSettings, doc: Doc, widths: Record<st
     "",
     'Answer as {"notes": {"<id>": "<sentence>"}} using exactly the id above.',
   ].join("\n");
-  const j = parseJsonObject(await complete(s, SYSTEM, user, signal));
+  const j = await completeObject(s, SYSTEM, user, signal);
   return pickStrings(j.notes, parts, 300)[itemId];
 }
 
@@ -216,7 +232,7 @@ export async function proposeDescription(s: AiSettings, doc: Doc, widths: Record
   ]
     .filter((l) => l !== "")
     .join("\n");
-  const j = parseJsonObject(await complete(s, SYSTEM, user, signal));
+  const j = await completeObject(s, SYSTEM, user, signal);
   const note = typeof j.description === "string" ? j.description.trim().slice(0, 400) : "";
   if (!note) throw new Error("json");
   const name = typeof j.name === "string" ? j.name.trim().slice(0, 40) : "";
@@ -247,7 +263,7 @@ export async function draftDesign(s: AiSettings, guide: string, idea: string, la
     guide,
   ].join("\n");
   const user = [`Sketch this app: ${idea.trim()}`, `Write every label, title and note in ${LANG_NAME[lang]}.`, "Three to five screens. Keep it simple."].join("\n");
-  const j = parseJsonObject(await complete(s, system, user, signal, 12000));
+  const j = await completeObject(s, system, user, signal, 12000);
   if (!isProject(j)) throw new Error("json");
   return j;
 }


### PR DESCRIPTION
Ask once more when a complete reply is not valid JSON

A reply that parses is used as it is. One that does not — a trailing comma,
a comment, a smart quote — now gets a single second request with the same
text plus the reminder that only the JSON object is wanted, so an otherwise
good answer is not thrown away. The retry is not taken for a reply the
provider cut off, which belongs to the prompt and the request budget, nor
after an abort, and a second bad reply fails exactly as the first one
would have.

Fixes #418.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A reply that parses is used as is. One that does not — trailing comma, comment, smart quote — gets one second request with the same text plus a reminder that only the JSON object is wanted, so a good answer isn't thrown away. The retry is skipped when the provider cut off the reply or after an abort, and a second bad reply fails exactly as the first would. Fixes #418.

<sup>Written for commit 7010708c18e13ed31c429540edf1a8fe316987a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

