### PR TITLE
Offer OpenRouter as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Works with any AI coding tool that takes a prompt, such as Claude Code, Codex, G
 - **Theme** – the four M3 Expressive axes in one panel. Color: seven presets or one seed color that becomes a full Material 3 scheme you can fine-tune, light / dark, three contrast levels and a dynamic-color switch (match the phone wallpaper). Shape: square, rounded or full corners for every part at once. Type: Roboto, Roboto Flex, Roboto Serif or the system font, with the emphasized styles. Motion: the standard or the expressive spring scheme, which also drives the preview.
 - **Prompt output** – the whole design (or a single screen) becomes a concise natural-language prompt in Japanese, English, Chinese or Korean, including your own notes on what each part does. Pick Android (the default) or the web as the target and the prompt asks for the matching stack.
 - **Tidy** – one button snaps bars to the edges, the FAB to the corner, joins neighbouring list items and buttons, and stacks the rest on 16dp margins. Press it again to undo.
-- **Optional AI helper** – bring your own key (OpenAI, Claude, Gemini or DeepSeek) and let the model write a part's behavior note or a screen's description, in your language. Each rewrite can be undone. The key stays in your browser and the request goes straight to the provider; there is no server in between.
+- **Optional AI helper** – bring your own key (OpenAI, Claude, Gemini, DeepSeek or OpenRouter) and let the model write a part's behavior note or a screen's description, in your language. Each rewrite can be undone. The key stays in your browser and the request goes straight to the provider; there is no server in between.
 - **Export** – copy the prompt (edit it by hand first if you like) or save a screen as a PNG.
 - **Share links and AI drafts (beta)** – copy a link that opens your design on anyone's canvas, or copy an instruction for Claude Code, Codex or another coding agent: it reads [agent.md](public/agent.md), sketches what you described, and replies with such a link.
 - **Alignment guides**, undo/redo, keyboard shortcuts, seven color themes, a favorites row in the parts panel, and everything is saved in your browser (localStorage).
@@ -139,7 +139,7 @@ Claude Code、Codex、Gemini CLI、Cursor など、プロンプトを受け取�
 - **テーマ** – M3 Expressive の 4 つの軸を 1 つのパネルで。カラーは 7 種のプリセットか、ベース色 1 つから Material 3 のスキーム全体を生成して微調整でき、ライト／ダーク、3 段階のコントラスト、壁紙に合わせるダイナミックカラーも指定できます。シェイプは全部品の角丸をスクエア／標準／フルでまとめて切り替え。タイポグラフィは Roboto、Roboto Flex、Roboto Serif、システムフォントと強調スタイル。モーションはスタンダード／エクスプレッシブで、プレビューの遷移にも反映されます。
 - **プロンプト出力** – デザイン全体、または 1 画面だけを、日本語・英語・中国語・韓国語の簡潔な文章にします。部品ごとの「振る舞い」メモもそのまま入ります。実装先は Android（既定）と Web から選べ、プロンプトはそれに合った技術で書かれます。
 - **整える** – ボタンひとつでバーを端に、FAB を隅に寄せ、隣り合うリスト項目やボタンをつなげ、残りを余白 16dp で積み直します。もう一度押すと元に戻ります。
-- **AI 補助（任意）** – 自分のキー（OpenAI、Claude、Gemini、DeepSeek）を入れると、部品の動作や画面の説明を UI の言語で書いてもらえます。書き換えは元に戻せます。キーはブラウザ内にだけ保存され、リクエストはプロバイダへ直接送られます（間にサーバーはありません）。
+- **AI 補助（任意）** – 自分のキー（OpenAI、Claude、Gemini、DeepSeek、OpenRouter）を入れると、部品の動作や画面の説明を UI の言語で書いてもらえます。書き換えは元に戻せます。キーはブラウザ内にだけ保存され、リクエストはプロバイダへ直接送られます（間にサーバーはありません）。
 - **書き出し** – プロンプトのコピー（手で編集してからも可）、画面の PNG 保存。
 - **共有リンクと AI の下書き（ベータ）** – 設計を相手のキャンバスで開けるリンクをコピーできます。Claude Code や Codex などのコーディングエージェント向けの指示もコピーでき、エージェントが [agent.md](public/agent.md) を読んでスケッチを作り、そのリンクで返してきます。
 - **補助線スナップ**、Undo/Redo、キーボードショートカット、7 種のカラーテーマ、お気に入り部品。作業内容はブラウザ（localStorage）に自動保存されます。
@@ -198,7 +198,7 @@ MIT © lnkiai
 - **主题** – 在一个面板里调整 M3 Expressive 的四个维度。配色：七套预设，或用一个基准色生成整套 Material 3 配色并微调，支持浅色／深色、三档对比度和动态配色（跟随手机壁纸）。形状：一次切换所有组件的圆角（方形／圆角／全圆）。字体：Roboto、Roboto Flex、Roboto Serif 或系统字体，并可开启强调样式。动效：标准或富有表现力的弹簧方案，同时作用于预览过渡。
 - **提示词输出** – 整个设计（或单个屏幕）会变成简洁的自然语言提示词，支持日文、英文、中文和韩文，并包含你为每个组件写的行为说明。目标平台可选 Android（默认）或 Web，提示词会相应地要求对应的技术栈。
 - **整理** – 一键把栏贴到边缘、FAB 放到角落、相邻的列表项和按钮连成一组，其余组件按 16dp 边距重新堆叠。再按一次即可撤销。
-- **AI 辅助（可选）** – 填入自己的密钥（OpenAI、Claude、Gemini 或 DeepSeek），让模型用界面语言写出组件的行为或屏幕的说明。每次改写都可以撤销。密钥只保存在浏览器中，请求直接发送给服务商，中间没有服务器。
+- **AI 辅助（可选）** – 填入自己的密钥（OpenAI、Claude、Gemini、DeepSeek 或 OpenRouter），让模型用界面语言写出组件的行为或屏幕的说明。每次改写都可以撤销。密钥只保存在浏览器中，请求直接发送给服务商，中间没有服务器。
 - **导出** – 复制提示词（也可先手动编辑），或把屏幕保存为 PNG。
 - **分享链接与 AI 草图（测试版）** – 复制一个能在他人画布上打开你设计的链接；也可以复制给 Claude Code、Codex 等编程代理的指令，代理会阅读 [agent.md](public/agent.md)、画出你描述的草图，并以这样的链接回复。
 - **对齐辅助线**、撤销／重做、键盘快捷键、收藏组件，所有内容自动保存在浏览器（localStorage）中。
@@ -257,7 +257,7 @@ Claude Code, Codex, Gemini CLI, Cursor 등 프롬프트를 받을 수 있는 AI 
 - **테마** – M3 Expressive의 네 가지 축을 한 패널에서. 색상은 7가지 프리셋 또는 기준 색상 하나로 Material 3 색상 구성 전체를 만들어 세부 조정할 수 있고, 라이트/다크, 3단계 대비, 배경화면에 맞추는 동적 색상도 지정합니다. 모양은 모든 부품의 모서리를 사각형/둥근형/완전 둥근형으로 한 번에 전환. 글꼴은 Roboto, Roboto Flex, Roboto Serif, 시스템 글꼴과 강조 스타일. 모션은 표준/익스프레시브이며 미리보기 전환에도 반영됩니다.
 - **프롬프트 출력** – 디자인 전체 또는 화면 하나를 일본어·영어·중국어·한국어의 간결한 문장으로 만듭니다. 부품별 "동작" 메모도 그대로 들어갑니다. 구현 대상은 Android(기본)와 웹 중에서 고를 수 있고, 프롬프트는 그에 맞는 기술로 작성됩니다.
 - **정리** – 버튼 하나로 바를 가장자리에, FAB를 모서리에 붙이고, 이웃한 목록 항목과 버튼을 연결하며, 나머지를 16dp 여백으로 다시 쌓습니다. 한 번 더 누르면 되돌립니다.
-- **AI 도우미(선택)** – 자신의 키(OpenAI, Claude, Gemini, DeepSeek)를 넣으면 부품의 동작이나 화면 설명을 UI 언어로 써 줍니다. 고쳐 쓴 내용은 되돌릴 수 있습니다. 키는 브라우저에만 저장되고 요청은 제공업체로 직접 전송됩니다(중간 서버 없음).
+- **AI 도우미(선택)** – 자신의 키(OpenAI, Claude, Gemini, DeepSeek, OpenRouter)를 넣으면 부품의 동작이나 화면 설명을 UI 언어로 써 줍니다. 고쳐 쓴 내용은 되돌릴 수 있습니다. 키는 브라우저에만 저장되고 요청은 제공업체로 직접 전송됩니다(중간 서버 없음).
 - **내보내기** – 프롬프트 복사(직접 편집한 뒤에도 가능), 화면의 PNG 저장.
 - **공유 링크와 AI 초안(베타)** – 설계를 다른 사람의 캔버스에서 여는 링크를 복사할 수 있습니다. Claude Code, Codex 같은 코딩 에이전트용 지시도 복사할 수 있으며, 에이전트가 [agent.md](public/agent.md)를 읽고 스케치를 만들어 그런 링크로 답합니다.
 - **정렬 안내선**, 실행 취소/다시 실행, 키보드 단축키, 7가지 색상 테마, 즐겨찾기 부품. 작업 내용은 브라우저(localStorage)에 자동 저장됩니다.

--- a/lib/ai.test.ts
+++ b/lib/ai.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { complete, hasKey, isSecureUrl, type AiSettings, type Provider } from "./ai";
+import { complete, hasKey, isSecureUrl, loadAiSettings, PROVIDERS, providerSpec, saveAiSettings, type AiSettings, type Provider } from "./ai";
 
 const settings = (over: Partial<AiSettings> = {}): AiSettings =>
   ({ provider: "openai", baseUrl: "https://api.example.test", model: "test-model", key: "test-key", ...over });
@@ -132,5 +132,47 @@ describe("hasKey and isSecureUrl", () => {
     expect(isSecureUrl("http://127.0.0.1:8080/v1")).toBe(true);
     expect(isSecureUrl("http://[::1]:8080/v1")).toBe(true);
     expect(isSecureUrl("http://api.example.test/v1")).toBe(false);
+  });
+});
+
+describe("the OpenRouter provider", () => {
+  it("is offered with the OpenAI-compatible base URL and its keys page", () => {
+    const spec = PROVIDERS.find((p) => p.key === "openrouter");
+    expect(spec?.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(spec?.keysUrl).toBe("https://openrouter.ai/keys");
+    expect(spec?.model.trim().length).toBeGreaterThan(0);
+    expect(providerSpec("openrouter").label).toBe("OpenRouter");
+  });
+
+  it("round-trips through the saved settings", () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    });
+    saveAiSettings({ provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1", model: "openrouter/auto", key: "test-key" });
+    expect(loadAiSettings()).toMatchObject({ provider: "openrouter", model: "openrouter/auto", key: "test-key" });
+  });
+
+  it("sends the attribution headers without the design hash", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "stop", message: { content: "ok" } }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", { location: { href: "https://m3e.example/#p=design" } });
+    await expect(complete(settings({ provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1" }), "s", "u")).resolves.toBe("ok");
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers["HTTP-Referer"]).toBe("https://m3e.example/");
+    expect(init.headers["HTTP-Referer"]).not.toContain("#");
+    expect(init.headers["X-Title"]).toBe("M3E Canvas");
+  });
+
+  it("leaves the other providers without attribution headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ choices: [{ finish_reason: "stop", message: { content: "ok" } }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", { location: { href: "https://m3e.example/#p=design" } });
+    await complete(settings(), "s", "u");
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty("HTTP-Referer");
+    expect(headers).not.toHaveProperty("X-Title");
   });
 });

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -8,7 +8,7 @@ import { Lang } from "./i18n";
  * prompt and a fixed JSON answer shape, and the result is only applied after the
  * author has looked at it. Coordinates are never touched by the model. */
 
-export type Provider = "claude" | "openai" | "gemini" | "deepseek";
+export type Provider = "claude" | "openai" | "gemini" | "deepseek" | "openrouter";
 
 export type AiSettings = {
   provider: Provider;
@@ -22,6 +22,7 @@ export const PROVIDERS: { key: Provider; label: string; baseUrl: string; model: 
   { key: "claude", label: "Claude", baseUrl: "https://api.anthropic.com", model: "claude-sonnet-5", keysUrl: "https://console.anthropic.com/settings/keys" },
   { key: "gemini", label: "Gemini", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", model: "gemini-3.8-flash", keysUrl: "https://aistudio.google.com/apikey" },
   { key: "deepseek", label: "DeepSeek", baseUrl: "https://api.deepseek.com/v1", model: "deepseek-v4-flash", keysUrl: "https://platform.deepseek.com/api_keys" },
+  { key: "openrouter", label: "OpenRouter", baseUrl: "https://openrouter.ai/api/v1", model: "openrouter/auto", keysUrl: "https://openrouter.ai/keys" },
 ];
 
 export const providerSpec = (k: Provider) => PROVIDERS.find((p) => p.key === k) ?? PROVIDERS[0];
@@ -104,6 +105,11 @@ export async function complete(s: AiSettings, system: string, user: string, sign
   }
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (s.key.trim()) headers.authorization = `Bearer ${s.key.trim()}`;
+  if (s.provider === "openrouter" && typeof window !== "undefined") {
+    /* optional attribution OpenRouter uses for its leaderboards; the #hash holds the design, so it stays here */
+    headers["HTTP-Referer"] = window.location.href.split("#")[0];
+    headers["X-Title"] = "M3E Canvas";
+  }
   const res = await fetch(`${base}/chat/completions`, {
     method: "POST",
     signal,


### PR DESCRIPTION
Offer OpenRouter as a provider

The provider list gains OpenRouter on the OpenAI-compatible path the other
endpoints already share, so one key can reach many models. The picker and
the settings round-trip already follow the list, so the entry is the whole
change.

Its two optional attribution headers are leaderboard metadata only, and the
referer stops at the fragment: the design travels in the hash, so it stays
in the browser. One configured model, like every other provider, and the
README provider list gains OpenRouter in all four languages.

Fixes #420.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenRouter as an AI provider, so one key can reach many models through the OpenAI-compatible endpoint.

- Sends OpenRouter's optional attribution headers only for this provider; the referer drops the `#hash` so the design stays in the browser.
- Adds OpenRouter to the README provider list in all four languages.
- Fixes #420.

<sup>Written for commit c936594a21f454139ca1b6b4a5bf6fc6acdfdd15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lnkiai/m3e-canvas/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

