### PR TITLE
Raise the selected part above its siblings in a connected run

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3073,13 +3073,20 @@ export default function Page() {
       const instantG = instantRef.current.has(g.id);
       const allOn = g.items.every((it) => selectedSet.has(it.id));
       const corners = freeRadii(g, widths);
+      /* hidden runs are connected too: only their members may lift above siblings when selected */
+      const runIds = new Set(
+        explodeGroup(g, widths)
+          .filter((r) => r.items.length > 1)
+          .flatMap((r) => r.items.map((it) => it.id)),
+      );
       return (
         <motion.div
           key={g.id}
           initial={false}
           animate={{ x: g.x - ox, y: g.y - oy }}
           transition={instantG ? INSTANT : OPEN}
-          style={{ position: "absolute", left: 0, top: 0, zIndex: modalRail ? 2 : undefined }}
+          /* keep any selection lift inside the group, so canvas-wide layer order is preserved */
+          style={{ position: "absolute", left: 0, top: 0, zIndex: modalRail ? 2 : undefined, isolation: "isolate" }}
         >
           {layoutOf(g, widths).map((pl) => (
             <div key={pl.item.id} style={{ position: "absolute", left: pl.x - g.x, top: pl.y - g.y }}>
@@ -3090,6 +3097,7 @@ export default function Page() {
                 radii={corners.get(pl.item.id)}
                 pressed={false}
                 selected={selectedSet.has(pl.item.id)}
+                inRun={runIds.has(pl.item.id)}
                 interactive={!handMode}
                 onPointerDown={(e) => onItemPointerDown(e, g, pl.index, pl.item)}
               />
@@ -3147,6 +3155,8 @@ export default function Page() {
           flexDirection: g.axis === "x" ? "row" : "column",
           alignItems: g.axis === "x" ? "center" : "stretch",
           gap: GAP,
+          /* keep any selection lift inside the run, so canvas-wide layer order is preserved */
+          isolation: "isolate",
         }}
       >
         {cells.map((c, r) => {
@@ -3190,6 +3200,7 @@ export default function Page() {
               radii={radii}
               pressed={pressedId === c.item.id}
               selected={selectedSet.has(c.item.id)}
+              inRun={g.items.length > 1}
               interactive={!handMode}
               onPointerDown={(e) => onItemPointerDown(e, g, c.index, c.item)}
             />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import {
   baseRadii,
   explodeGroup,
   freeRadii,
+  radiiOfRuns,
   BEZEL,
   canJoin,
   clamp,
@@ -3072,10 +3073,12 @@ export default function Page() {
     if (g.free) {
       const instantG = instantRef.current.has(g.id);
       const allOn = g.items.every((it) => selectedSet.has(it.id));
-      const corners = freeRadii(g, widths);
+      /* explode once: the runs feed both the corner radii and the lift gate below */
+      const runs = explodeGroup(g, widths);
+      const corners = radiiOfRuns(runs);
       /* hidden runs are connected too: only their members may lift above siblings when selected */
       const runIds = new Set(
-        explodeGroup(g, widths)
+        runs
           .filter((r) => r.items.length > 1)
           .flatMap((r) => r.items.map((it) => it.id)),
       );

--- a/components/M3Node.tsx
+++ b/components/M3Node.tsx
@@ -1324,6 +1324,7 @@ export function M3Node({
   pressed,
   dragging,
   selected,
+  inRun = false,
   interactive = true,
   onPointerDown,
   tabScroll,
@@ -1335,6 +1336,8 @@ export function M3Node({
   pressed?: boolean;
   dragging?: boolean;
   selected?: boolean;
+  /** the part sits in a connected run (non-free group, or a hidden run inside a free group) */
+  inRun?: boolean;
   interactive?: boolean;
   onPointerDown?: (e: React.PointerEvent) => void;
   /** how far a scrollable tab row is scrolled in the preview; the canvas uses the resting position */
@@ -1376,10 +1379,12 @@ export function M3Node({
         display: measured ? "inline-flex" : "block",
         alignItems: "center",
         overflow: clips ? "hidden" : "visible",
-        /* the selection ring sticks out 5px (3px offset + 2px ring); in a connected run the next
-           sibling sits 3px below and would overpaint its bottom edge — lift selected parts instead */
-        position: selected ? "relative" : undefined,
-        zIndex: selected ? 1 : undefined,
+        /* the selection ring sticks out 5px (3px offset + 2px ring); in a run the next
+           sibling sits 3px away and would overpaint that edge — lift the selected part.
+           Runs never overlap, so the lift only beats the sibling that hides the ring.
+           Lone parts in free groups may overlap by design: keep their layer order. */
+        position: selected && inRun ? "relative" : undefined,
+        zIndex: selected && inRun ? 1 : undefined,
         cursor: !interactive ? "default" : dragging ? "grabbing" : "grab",
         userSelect: "none",
         touchAction: "none",

--- a/components/M3Node.tsx
+++ b/components/M3Node.tsx
@@ -1376,6 +1376,10 @@ export function M3Node({
         display: measured ? "inline-flex" : "block",
         alignItems: "center",
         overflow: clips ? "hidden" : "visible",
+        /* the selection ring sticks out 5px (3px offset + 2px ring); in a connected run the next
+           sibling sits 3px below and would overpaint its bottom edge — lift selected parts instead */
+        position: selected ? "relative" : undefined,
+        zIndex: selected ? 1 : undefined,
         cursor: !interactive ? "default" : dragging ? "grabbing" : "grab",
         userSelect: "none",
         touchAction: "none",

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1590,10 +1590,10 @@ export function runCorners(axis: Axis, first: boolean, last: boolean, outer: num
   return axis === "x" ? { tl: a, bl: a, tr: b, br: b } : { tl: a, tr: a, bl: b, br: b };
 }
 
-/** the corner radii of every part in a free group, with its hidden runs kept connected */
-export function freeRadii(g: Group, widths: Record<string, number>): Map<string, Radii> {
+/** the corner radii of every part across the given runs */
+export function radiiOfRuns(runs: Group[]): Map<string, Radii> {
   const out = new Map<string, Radii>();
-  for (const run of explodeGroup(g, widths)) {
+  for (const run of runs) {
     const n = run.items.length;
     run.items.forEach((it, i) => {
       const c = connectSpecOf(it);
@@ -1601,6 +1601,11 @@ export function freeRadii(g: Group, widths: Record<string, number>): Map<string,
     });
   }
   return out;
+}
+
+/** the corner radii of every part in a free group, with its hidden runs kept connected */
+export function freeRadii(g: Group, widths: Record<string, number>): Map<string, Radii> {
+  return radiiOfRuns(explodeGroup(g, widths));
 }
 
 /** a run belongs to the frame that contains its centre */


### PR DESCRIPTION
Fixes #415.

## Problem

A selected part draws a 2px outline 3px outside its box, so the ring reaches 5px past the edge. Parts in a connected run sit only 3px apart (`GAP`), so the next part's opaque background paints over the ring's trailing edge.

### Before (bottom edge missing)

![Before: the selection ring's bottom edge is covered by the next list item](https://raw.githubusercontent.com/Cokedog320/m3e-canvas/assets/selection-ring/pr-414/selection-ring-before.png)

## Fix

Implements the approach agreed in #415: the ring itself is untouched (2px at a 3px offset). When a part in a connected run is selected, it is raised above its siblings with `position: relative; z-index: 1`. Runs never overlap, so the lift only beats the sibling that was hiding the ring; when adjacent parts are selected together, the later one covers the shared edge and the two rings read as one outline, as discussed there.

The lift is scoped so it can't affect anything outside the connected run.

Supersedes #414, which was closed because it shrank the ring instead of raising the part.

## Validation

- `npm run build`, `npm run typecheck`, and `npm test` (664 tests) pass
- Verified in the editor: a single selected list item now shows all four edges; adjacent selected items render as one continuous outline; the Layers-panel order of overlapping free groups is unchanged

Editor check after the fix on this branch:

![The selected list item now shows the full ring on all four sides](https://raw.githubusercontent.com/Cokedog320/m3e-canvas/assets/selection-ring/pr-430/editor-verified.png)
